### PR TITLE
feat: 사용자 비밀번호 초기화 기능 추가

### DIFF
--- a/src/main/java/com/backend/komeet/controller/UserController.java
+++ b/src/main/java/com/backend/komeet/controller/UserController.java
@@ -3,10 +3,7 @@ package com.backend.komeet.controller;
 import com.backend.komeet.config.JwtProvider;
 import com.backend.komeet.dto.UserDto;
 import com.backend.komeet.dto.UserSignInDto;
-import com.backend.komeet.dto.request.UserEmailRequest;
-import com.backend.komeet.dto.request.UserInfoUpdateRequest;
-import com.backend.komeet.dto.request.UserSignInRequest;
-import com.backend.komeet.dto.request.UserSignUpRequest;
+import com.backend.komeet.dto.request.*;
 import com.backend.komeet.dto.response.UserSignInResponse;
 import com.backend.komeet.service.external.EmailService;
 import com.backend.komeet.service.external.GeocoderService;
@@ -24,11 +21,9 @@ import org.springframework.web.bind.annotation.*;
 import javax.validation.Valid;
 import java.util.concurrent.CompletableFuture;
 
-import static com.backend.komeet.enums.EmailComponents.EMAIL_SIGN_UP_CONTENT;
-import static com.backend.komeet.enums.EmailComponents.EMAIL_SIGN_UP_SUBJECT;
+import static com.backend.komeet.enums.EmailComponents.*;
 import static org.springframework.http.HttpHeaders.AUTHORIZATION;
-import static org.springframework.http.HttpStatus.CREATED;
-import static org.springframework.http.HttpStatus.OK;
+import static org.springframework.http.HttpStatus.*;
 
 /**
  * 사용자 관련 컨트롤러
@@ -161,4 +156,20 @@ public class UserController {
         return ResponseEntity.status(OK).build();
     }
 
+    @PatchMapping("/password/reset")
+    @ApiOperation(value = "비밀번호 재설정", notes = "비밀번호 재설정 진행")
+    public ResponseEntity<Void> resetPassword(
+            @Valid @RequestBody UserPasswordResetRequest passwordResetRequest) {
+
+        String temporaryPassword =
+                userInformationService.resetPassword(passwordResetRequest);
+
+        emailService.sendEmail(
+                passwordResetRequest.getEmail(),
+                PASSWORD_RESET_SUBJECT,
+                String.format(PASSWORD_RESET_CONTENT, temporaryPassword)
+        );
+
+        return ResponseEntity.status(NO_CONTENT).build();
+    }
 }

--- a/src/main/java/com/backend/komeet/dto/request/UserPasswordResetRequest.java
+++ b/src/main/java/com/backend/komeet/dto/request/UserPasswordResetRequest.java
@@ -1,0 +1,16 @@
+package com.backend.komeet.dto.request;
+
+import com.backend.komeet.enums.Countries;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class UserPasswordResetRequest {
+    private String email;
+    private Countries country;
+}

--- a/src/main/java/com/backend/komeet/enums/EmailComponents.java
+++ b/src/main/java/com/backend/komeet/enums/EmailComponents.java
@@ -9,4 +9,8 @@ public class EmailComponents {
     public static final String EMAIL_SIGN_UP_CONTENT =
             "아래 링크를 클릭하시면 회원가입 인증이 완료됩니다.\n" +
                     "http://localhost:8080/api/v1/users/%d/verification";
+    public static final String PASSWORD_RESET_SUBJECT =
+            "ko-meet 비밀번호가 초기화 되었습니다.";
+    public static final String PASSWORD_RESET_CONTENT =
+            "아래 임시 비밀번호를 통해 로그인 후 비밀번호를 변경해주세요.\n 임시 비밀번호 : %s";
 }

--- a/src/main/java/com/backend/komeet/service/user/UserInformationService.java
+++ b/src/main/java/com/backend/komeet/service/user/UserInformationService.java
@@ -2,11 +2,14 @@ package com.backend.komeet.service.user;
 
 import com.backend.komeet.domain.User;
 import com.backend.komeet.dto.request.UserInfoUpdateRequest;
+import com.backend.komeet.dto.request.UserPasswordResetRequest;
 import com.backend.komeet.exception.CustomException;
 import com.backend.komeet.repository.UserRepository;
 import com.backend.komeet.util.CountryUtil;
+import com.backend.komeet.util.UUIDUtil;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.util.Pair;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -18,6 +21,7 @@ import static com.backend.komeet.exception.ErrorCode.USER_INFO_NOT_FOUND;
 @Service
 public class UserInformationService {
     private final UserRepository userRepository;
+    private final PasswordEncoder passwordEncoder;
 
     /**
      * 사용자 정보 수정
@@ -44,5 +48,26 @@ public class UserInformationService {
             user.setRegion(countryPair.getSecond());
             user.setCountry(userInfoUpdateRequest.getCountry());
         }
+    }
+
+    /**
+     * 사용자 비밀번호 초기화
+     *
+     * @param userPasswordResetRequest 사용자 번호
+     * @return 사용자 번호
+     */
+    @Transactional
+    public String resetPassword(UserPasswordResetRequest userPasswordResetRequest) {
+        User user = userRepository.findByEmail(userPasswordResetRequest.getEmail())
+                .orElseThrow(() -> new CustomException(USER_INFO_NOT_FOUND));
+
+        if (!user.getCountry().equals(userPasswordResetRequest.getCountry())) {
+            throw new CustomException(USER_INFO_NOT_FOUND);
+        }
+
+        String temporaryPassword = UUIDUtil.generateUUID(10);
+        user.setPassword(passwordEncoder.encode(temporaryPassword));
+
+        return temporaryPassword;
     }
 }

--- a/src/main/java/com/backend/komeet/util/UUIDUtil.java
+++ b/src/main/java/com/backend/komeet/util/UUIDUtil.java
@@ -1,0 +1,18 @@
+package com.backend.komeet.util;
+
+import lombok.experimental.UtilityClass;
+
+@UtilityClass
+public class UUIDUtil {
+    /**
+     * UUID 생성
+     *
+     * @return UUID
+     */
+    public String generateUUID(Integer length) {
+        return java.util.UUID.randomUUID()
+                .toString()
+                .replace("-", "")
+                .substring(0, length);
+    }
+}

--- a/src/test/java/com/backend/komeet/service/user/KoMeetApplicationTests.java
+++ b/src/test/java/com/backend/komeet/service/user/KoMeetApplicationTests.java
@@ -1,4 +1,4 @@
-package com.community.komeet;
+package com.backend.komeet.service.user;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;

--- a/src/test/java/com/backend/komeet/service/user/service/user/UserInformationServiceTest.java
+++ b/src/test/java/com/backend/komeet/service/user/service/user/UserInformationServiceTest.java
@@ -5,7 +5,6 @@ import com.backend.komeet.dto.request.UserPasswordResetRequest;
 import com.backend.komeet.enums.Countries;
 import com.backend.komeet.repository.UserRepository;
 import com.backend.komeet.service.user.UserInformationService;
-import com.backend.komeet.util.UUIDUtil;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;

--- a/src/test/java/com/backend/komeet/service/user/service/user/UserInformationServiceTest.java
+++ b/src/test/java/com/backend/komeet/service/user/service/user/UserInformationServiceTest.java
@@ -1,0 +1,65 @@
+package com.backend.komeet.service.user.service.user;
+
+import com.backend.komeet.domain.User;
+import com.backend.komeet.dto.request.UserPasswordResetRequest;
+import com.backend.komeet.enums.Countries;
+import com.backend.komeet.repository.UserRepository;
+import com.backend.komeet.service.user.UserInformationService;
+import com.backend.komeet.util.UUIDUtil;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+import java.util.Optional;
+
+import static org.mockito.Mockito.when;
+
+@DisplayName("사용자 비밀번호 초기화 테스트")
+class UserInformationServiceTest {
+
+    @Mock
+    private UserRepository userRepository;
+    @Mock
+    private PasswordEncoder passwordEncoder;
+    private UserInformationService userInformationService;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.initMocks(this);
+        userInformationService =
+                new UserInformationService(userRepository, passwordEncoder);
+    }
+
+    @Test
+    @DisplayName("성공")
+    void resetPassword_Success() {
+        //given
+        User user = User.builder()
+                .email("test@test.test")
+                .password("test")
+                .country(Countries.SOUTH_KOREA)
+                .build();
+
+        UserPasswordResetRequest userPasswordResetRequest =
+                UserPasswordResetRequest.builder()
+                        .email("test@test.test")
+                        .country(Countries.SOUTH_KOREA)
+                        .build();
+
+        when(userRepository.findByEmail(userPasswordResetRequest.getEmail()))
+                .thenReturn(Optional.of(user));
+        when(passwordEncoder.encode(Mockito.anyString()))
+                .thenReturn("encodedPw");
+        //when
+        String tempPassword =
+                userInformationService.resetPassword(userPasswordResetRequest);
+        //then
+        Assertions.assertThat(tempPassword).isNotEqualTo("test");
+    }
+
+}

--- a/src/test/java/com/backend/komeet/service/user/service/user/UserSignInServiceTest.java
+++ b/src/test/java/com/backend/komeet/service/user/service/user/UserSignInServiceTest.java
@@ -1,4 +1,4 @@
-package com.community.komeet.service.user;
+package com.backend.komeet.service.user.service.user;
 
 import com.backend.komeet.config.JwtProvider;
 import com.backend.komeet.domain.User;

--- a/src/test/java/com/backend/komeet/service/user/service/user/UserSignUpServiceTest.java
+++ b/src/test/java/com/backend/komeet/service/user/service/user/UserSignUpServiceTest.java
@@ -1,4 +1,4 @@
-package com.community.komeet.service.user;
+package com.backend.komeet.service.user.service.user;
 
 import com.backend.komeet.domain.User;
 import com.backend.komeet.dto.request.UserSignUpRequest;


### PR DESCRIPTION
### 작업 내용
- 사용자 비밀번호 초기화 기능 추가

### 변경 사항(추가시엔 추가사항)
- 10자리 UUID ( "-" 제외) 생성하여 저장 및 이메일로 임시비밀번호 전송

### 특이 사항
- 없음.

### 테스트
- [x] 테스트 코드
- [x] api 테스트

### 관련 이슈(옵셔널)
- 없음