### PR TITLE
fix: 북마크 해제 시 게시물 삭제되는 이슈 수정

### DIFF
--- a/src/main/java/com/backend/komeet/domain/Bookmark.java
+++ b/src/main/java/com/backend/komeet/domain/Bookmark.java
@@ -19,7 +19,7 @@ public class Bookmark extends BaseEntity {
     private Long bookmarkSeq;
     private Long userSeq;
 
-    @OneToMany(cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.EAGER)
+    @OneToMany(orphanRemoval = true, fetch = FetchType.EAGER)
     private List<Post> bookmarkPosts;
 
 }


### PR DESCRIPTION
### 작업 내용
- 북마크 해제 시 게시물 삭제되는 이슈 수정

### 변경 사항(추가시엔 추가사항)
- `@ManyToOne`의 불필요한 `casacade` 옵션 제거

### 특이 사항
- 없음
### 테스트
- [x] 테스트 코드
- [x] api 테스트

### 관련 이슈(옵셔널)
- 없음