### PR TITLE
feat: 토크 리프레시 시 다시 토큰을 저장하도록 수정

### DIFF
--- a/src/main/java/com/backend/komeet/controller/AuthController.java
+++ b/src/main/java/com/backend/komeet/controller/AuthController.java
@@ -3,6 +3,7 @@ package com.backend.komeet.controller;
 import com.backend.komeet.config.JwtProvider;
 import com.backend.komeet.dto.UserSignInDto;
 import com.backend.komeet.dto.response.ApiResponse;
+import com.backend.komeet.dto.response.RefreshTokenResponse;
 import com.backend.komeet.service.external.GeocoderService;
 import com.backend.komeet.service.user.UserInformationService;
 import io.swagger.annotations.Api;
@@ -50,8 +51,13 @@ public class AuthController {
     @ApiOperation(value = "토큰 재발급", notes = "토큰 재발급 진행")
     public ResponseEntity<ApiResponse> refresh(
             @RequestParam("token") String refreshToken) {
-        String newAccessToken =
+        Pair<String,String> newAccessToken =
                 userInformationService.refreshToken(refreshToken);
-        return ResponseEntity.status(OK).body(new ApiResponse(newAccessToken));
+
+        RefreshTokenResponse refreshTokenResponse = RefreshTokenResponse.from(
+                newAccessToken.getFirst(),
+                newAccessToken.getSecond()
+        );
+        return ResponseEntity.status(OK).body(new ApiResponse(refreshTokenResponse));
     }
 }

--- a/src/main/java/com/backend/komeet/dto/response/RefreshTokenResponse.java
+++ b/src/main/java/com/backend/komeet/dto/response/RefreshTokenResponse.java
@@ -1,0 +1,22 @@
+package com.backend.komeet.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class RefreshTokenResponse {
+    private String accessToken;
+    private String refreshToken;
+
+    public static RefreshTokenResponse from(String accessToken, String refreshToken) {
+        return RefreshTokenResponse.builder()
+                .accessToken(accessToken)
+                .refreshToken(refreshToken)
+                .build();
+    }
+}

--- a/src/main/java/com/backend/komeet/service/external/RedisService.java
+++ b/src/main/java/com/backend/komeet/service/external/RedisService.java
@@ -41,4 +41,8 @@ public class RedisService {
         ValueOperations<String, String> ops = stringRedisTemplate.opsForValue();
         return ops.get(refreshToken);
     }
+
+    public void deleteValueByKey(String refreshToken) {
+        stringRedisTemplate.delete(refreshToken);
+    }
 }


### PR DESCRIPTION
### 작업 내용
- 토큰 리프레시 시 다시 토큰을 저장하도록 수정

### 변경 사항(추가시엔 추가사항)
- 위와 동

### 특이 사항
- 없음

### 테스트
- [x] 테스트 코드
- [x] api 테스트

### 관련 이슈(옵셔널)
- 없음