### PR TITLE
fix: 대댓글 엔티티 id 생성값 추가

### DIFF
--- a/src/main/java/com/backend/komeet/controller/ReplyController.java
+++ b/src/main/java/com/backend/komeet/controller/ReplyController.java
@@ -1,0 +1,40 @@
+package com.backend.komeet.controller;
+
+import com.backend.komeet.config.JwtProvider;
+import com.backend.komeet.dto.request.CommentUploadRequest;
+import com.backend.komeet.dto.response.ApiResponse;
+import com.backend.komeet.service.comment.CommentUploadService;
+import com.backend.komeet.service.reply.ReplyUploadService;
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import javax.validation.Valid;
+
+import static org.apache.http.HttpHeaders.AUTHORIZATION;
+import static org.springframework.http.HttpStatus.CREATED;
+
+@Api(tags = "Reply API", description = "대댓글 관련 API")
+@RequestMapping("/api/v1/replies")
+@RequiredArgsConstructor
+@RestController
+public class ReplyController {
+    private final ReplyUploadService replyUploadService;
+    private final JwtProvider jwtProvider;
+
+    @PostMapping("/comments/{commentSeq}")
+    @ApiOperation(value = "대댓글 작성", notes = "대댓글을 작성합니다.")
+    public ResponseEntity<ApiResponse> createReply(
+            @PathVariable Long commentSeq,
+            @RequestHeader(AUTHORIZATION) String token,
+            @Valid @RequestBody CommentUploadRequest commentUploadRequest) {
+
+        Long userId = jwtProvider.getIdFromToken(token);
+
+        replyUploadService.uploadComment(userId, commentSeq, commentUploadRequest);
+
+        return ResponseEntity.status(CREATED).body(new ApiResponse(CREATED.value()));
+    }
+}

--- a/src/main/java/com/backend/komeet/domain/Reply.java
+++ b/src/main/java/com/backend/komeet/domain/Reply.java
@@ -21,6 +21,7 @@ import javax.persistence.*;
 @Entity
 public class Reply {
     @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long seq;
 
     @ManyToOne

--- a/src/main/java/com/backend/komeet/domain/Reply.java
+++ b/src/main/java/com/backend/komeet/domain/Reply.java
@@ -1,6 +1,7 @@
 package com.backend.komeet.domain;
 
 import com.backend.komeet.enums.PostStatus;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -29,6 +30,7 @@ public class Reply {
 
     @ManyToOne
     @JoinColumn(name = "comment_seq")
+    @JsonIgnore
     private Comment comment;
 
     private int upVotes;
@@ -37,4 +39,15 @@ public class Reply {
 
     @Enumerated(EnumType.STRING)
     private PostStatus status;
+
+    public static Reply from(User user, Comment comment, String content) {
+        return Reply.builder()
+                .author(user)
+                .comment(comment)
+                .content(content)
+                .upVotes(0)
+                .downVotes(0)
+                .status(PostStatus.NORMAL)
+                .build();
+    }
 }

--- a/src/main/java/com/backend/komeet/exception/ErrorCode.java
+++ b/src/main/java/com/backend/komeet/exception/ErrorCode.java
@@ -30,7 +30,9 @@ public enum ErrorCode {
     //post
     POST_NOT_FOUND(NOT_FOUND, "존재하지 않는 게시물입니다."),
     NO_AUTHORITY(BAD_REQUEST, "본인이 작성한 글만 수정하거나 삭제할 수 있습니다."),
-    ALREADY_DELETED_POST(BAD_REQUEST, "이미 삭제된 게시물입니다.");
+    ALREADY_DELETED_POST(BAD_REQUEST, "이미 삭제된 게시물입니다."),
+
+    COMMENT_NOT_FOUND(NOT_FOUND, "존재하지 않는 댓글입니다.");
 
     private final HttpStatus status;
     private final String message;

--- a/src/main/java/com/backend/komeet/repository/ReplyRepository.java
+++ b/src/main/java/com/backend/komeet/repository/ReplyRepository.java
@@ -1,0 +1,7 @@
+package com.backend.komeet.repository;
+
+import com.backend.komeet.domain.Reply;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ReplyRepository extends JpaRepository<Reply, Long> {
+}

--- a/src/main/java/com/backend/komeet/service/reply/ReplyUploadService.java
+++ b/src/main/java/com/backend/komeet/service/reply/ReplyUploadService.java
@@ -1,0 +1,51 @@
+package com.backend.komeet.service.reply;
+
+import com.backend.komeet.domain.Comment;
+import com.backend.komeet.domain.Reply;
+import com.backend.komeet.domain.User;
+import com.backend.komeet.dto.request.CommentUploadRequest;
+import com.backend.komeet.exception.CustomException;
+import com.backend.komeet.exception.ErrorCode;
+import com.backend.komeet.repository.CommentRepository;
+import com.backend.komeet.repository.ReplyRepository;
+import com.backend.komeet.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import static com.backend.komeet.exception.ErrorCode.USER_INFO_NOT_FOUND;
+
+@Slf4j
+@RequiredArgsConstructor
+@Service
+public class ReplyUploadService {
+    private final ReplyRepository replyRepository;
+    private final UserRepository userRepository;
+    private final CommentRepository commentRepository;
+
+
+    /**
+     * 대댓글을 업로드하는 메서드
+     * @param userId 사용자 식별자
+     * @param commentSeq 댓글 식별자
+     * @param commentUploadRequest 대댓글 업로드 요청 데이터
+     */
+    @Transactional
+    public void uploadComment(Long userId,
+                              Long commentSeq,
+                              CommentUploadRequest commentUploadRequest) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new CustomException(USER_INFO_NOT_FOUND));
+
+        Comment comment = commentRepository.findById(commentSeq)
+                .orElseThrow(() -> new CustomException(ErrorCode.COMMENT_NOT_FOUND));
+
+        Reply reply = replyRepository.save(
+                Reply.from(user, comment, commentUploadRequest.getContent())
+        );
+
+        comment.getReplies().add(reply);
+    }
+
+}


### PR DESCRIPTION
### 작업 내용
- 대댓글 엔티티 id 생성값 추가

### 변경 사항(추가시엔 추가사항)
- `strategy = GenerationType.IDENTITY` 추가

### 특이 사항
- 없음

### 테스트
- [x] 테스트 코드
- [x] api 테스트

### 관련 이슈(옵셔널)
- 없음