### PR TITLE
feat: 댓글, 대댓글 좋아요 기능 추가

### DIFF
--- a/src/main/java/com/backend/komeet/controller/CommentController.java
+++ b/src/main/java/com/backend/komeet/controller/CommentController.java
@@ -3,6 +3,7 @@ package com.backend.komeet.controller;
 import com.backend.komeet.config.JwtProvider;
 import com.backend.komeet.dto.request.CommentUploadRequest;
 import com.backend.komeet.dto.response.ApiResponse;
+import com.backend.komeet.service.comment.CommentLikeService;
 import com.backend.komeet.service.comment.CommentUploadService;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
@@ -21,6 +22,7 @@ import static org.springframework.http.HttpStatus.CREATED;
 @RestController
 public class CommentController {
     private final CommentUploadService commentUploadService;
+    private final CommentLikeService commentLikeService;
     private final JwtProvider jwtProvider;
 
     @PostMapping("/posts/{postSeq}")
@@ -33,6 +35,19 @@ public class CommentController {
         Long userId = jwtProvider.getIdFromToken(token);
 
         commentUploadService.uploadComment(userId, postSeq, commentUploadRequest);
+
+        return ResponseEntity.status(CREATED).body(new ApiResponse(CREATED.value()));
+    }
+
+    @PatchMapping("/{commentSeq}/like")
+    @ApiOperation(value = "댓글 좋아요", notes = "댓글에 좋아요를 누릅니다.")
+    public ResponseEntity<ApiResponse> likeComment(
+            @PathVariable Long commentSeq,
+            @RequestHeader(AUTHORIZATION) String token) {
+
+        Long userId = jwtProvider.getIdFromToken(token);
+
+        commentLikeService.likeComment(userId, commentSeq);
 
         return ResponseEntity.status(CREATED).body(new ApiResponse(CREATED.value()));
     }

--- a/src/main/java/com/backend/komeet/controller/PostController.java
+++ b/src/main/java/com/backend/komeet/controller/PostController.java
@@ -86,9 +86,9 @@ public class PostController {
 
         Long userId = jwtProvider.getIdFromToken(token);
 
-        Long likeCount = postLikeService.likePost(userId, postSeq);
+        postLikeService.likePost(userId, postSeq);
 
-        return ResponseEntity.status(OK).body(new ApiResponse(likeCount));
+        return ResponseEntity.status(NO_CONTENT).body(new ApiResponse(NO_CONTENT.value()));
     }
 
     @GetMapping

--- a/src/main/java/com/backend/komeet/controller/ReplyController.java
+++ b/src/main/java/com/backend/komeet/controller/ReplyController.java
@@ -4,6 +4,7 @@ import com.backend.komeet.config.JwtProvider;
 import com.backend.komeet.dto.request.CommentUploadRequest;
 import com.backend.komeet.dto.response.ApiResponse;
 import com.backend.komeet.service.comment.CommentUploadService;
+import com.backend.komeet.service.reply.ReplyLikeService;
 import com.backend.komeet.service.reply.ReplyUploadService;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
@@ -22,6 +23,7 @@ import static org.springframework.http.HttpStatus.CREATED;
 @RestController
 public class ReplyController {
     private final ReplyUploadService replyUploadService;
+    private final ReplyLikeService replyLikeService;
     private final JwtProvider jwtProvider;
 
     @PostMapping("/comments/{commentSeq}")
@@ -34,6 +36,19 @@ public class ReplyController {
         Long userId = jwtProvider.getIdFromToken(token);
 
         replyUploadService.uploadComment(userId, commentSeq, commentUploadRequest);
+
+        return ResponseEntity.status(CREATED).body(new ApiResponse(CREATED.value()));
+    }
+
+    @PatchMapping("/{replySeq}/like")
+    @ApiOperation(value = "대댓글 좋아요", notes = "대댓글에 좋아요를 누릅니다.")
+    public ResponseEntity<ApiResponse> likeReply(
+            @PathVariable Long replySeq,
+            @RequestHeader(AUTHORIZATION) String token) {
+
+        Long userId = jwtProvider.getIdFromToken(token);
+
+        replyLikeService.likeReply(userId, replySeq);
 
         return ResponseEntity.status(CREATED).body(new ApiResponse(CREATED.value()));
     }

--- a/src/main/java/com/backend/komeet/domain/Comment.java
+++ b/src/main/java/com/backend/komeet/domain/Comment.java
@@ -2,10 +2,8 @@ package com.backend.komeet.domain;
 
 import com.backend.komeet.enums.PostStatus;
 import com.fasterxml.jackson.annotation.JsonIgnore;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
+import org.hibernate.annotations.Cascade;
 import org.hibernate.annotations.DynamicUpdate;
 
 import javax.persistence.*;
@@ -42,6 +40,11 @@ public class Comment extends BaseEntity {
     @OneToMany(mappedBy = "comment", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<Reply> replies = new ArrayList<>();
 
+    @ElementCollection
+    @Cascade(org.hibernate.annotations.CascadeType.ALL)
+    private List<Long> likeUsers;
+
+    @Setter
     private int upVotes;
     private int downVotes;
 

--- a/src/main/java/com/backend/komeet/domain/Reply.java
+++ b/src/main/java/com/backend/komeet/domain/Reply.java
@@ -2,13 +2,12 @@ package com.backend.komeet.domain;
 
 import com.backend.komeet.enums.PostStatus;
 import com.fasterxml.jackson.annotation.JsonIgnore;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
+import org.hibernate.annotations.Cascade;
 import org.hibernate.annotations.DynamicUpdate;
 
 import javax.persistence.*;
+import java.util.List;
 
 /**
  * 대댓글 엔티티
@@ -34,9 +33,14 @@ public class Reply extends BaseEntity {
     @JsonIgnore
     private Comment comment;
 
-    private int upVotes;
+    @Setter
+    private Integer upVotes;
 
-    private int downVotes;
+    @ElementCollection
+    @Cascade(org.hibernate.annotations.CascadeType.ALL)
+    private List<Long> likeUsers;
+
+    private Integer downVotes;
 
     @Enumerated(EnumType.STRING)
     private PostStatus status;

--- a/src/main/java/com/backend/komeet/service/comment/CommentLikeService.java
+++ b/src/main/java/com/backend/komeet/service/comment/CommentLikeService.java
@@ -1,0 +1,107 @@
+package com.backend.komeet.service.comment;
+
+import com.backend.komeet.component.RedisDistributedLock;
+import com.backend.komeet.domain.Comment;
+import com.backend.komeet.exception.CustomException;
+import com.backend.komeet.repository.CommentRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+import static com.backend.komeet.exception.ErrorCode.COMMENT_NOT_FOUND;
+
+@Slf4j
+@RequiredArgsConstructor
+@Service
+public class CommentLikeService {
+    private final CommentRepository commentRepository;
+    private final RedisDistributedLock redisDistributedLock;
+    final String LOCK_KEY = "likeComment : ";
+
+    /**
+     * 대댓글 좋아요를 처리하는 메서드
+     *
+     * @param userSeq  사용자 식별자
+     * @param commentSeq 대댓글 식별자
+     */
+    @Async
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void likeComment(Long userSeq, Long commentSeq) {
+        int maxRetries = 3;
+        int retries = 0;
+        long retryIntervalMillis = 1000; // 1초 간격으로 재시도
+        Integer likeCount = null;
+
+        while (retries <= maxRetries) {
+            try {
+                likeCount = processLike(userSeq, commentSeq);
+                if (likeCount != null) {
+                    break;
+                } else {
+                    log.error("Failed to acquire lock for commentSeq: {}", commentSeq);
+                }
+            } catch (CustomException e) {
+                log.error(e.getMessage());
+            }
+            if (retries < maxRetries) {
+                retries++;
+                try {
+                    Thread.sleep(retryIntervalMillis);
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                }
+            }
+        }
+        if (likeCount == null) {
+            log.error("Failed to process like for commentSeq {} after {} retries", commentSeq, maxRetries);
+        }
+    }
+
+    /**
+     * 좋아요 작업을 처리하는 메서드
+     *
+     * @param userSeq 사용자 식별자
+     * @param commentSeq 게시물 식별자
+     * @return 작업 성공 여부
+     * @throws CustomException 작업 실패
+     */
+    private Integer processLike(Long userSeq, Long commentSeq) throws CustomException {
+        Comment comment = getComment(commentSeq);
+
+        boolean lockAcquired = false;
+        try {
+            lockAcquired = redisDistributedLock.acquireLock(
+                    LOCK_KEY, commentSeq.toString(), 10
+            );
+            if (lockAcquired) {
+                if (comment.getLikeUsers().remove(userSeq)) {
+                    comment.setUpVotes(comment.getUpVotes() - 1);
+                } else {
+                    comment.getLikeUsers().add(userSeq);
+                    comment.setUpVotes(comment.getUpVotes() + 1);
+                }
+                return commentRepository.save(comment).getUpVotes();
+            } else {
+                return null;
+            }
+        } finally {
+            if (lockAcquired) {
+                redisDistributedLock.releaseLock(LOCK_KEY, commentSeq.toString());
+            }
+        }
+    }
+
+    /**
+     * 게시물 식별자로 게시물을 조회하는 메서드
+     *
+     * @param seq 게시물 식별자
+     * @return 게시물
+     */
+    private Comment getComment(Long seq) {
+        return commentRepository.findById(seq)
+                .orElseThrow(() -> new CustomException(COMMENT_NOT_FOUND));
+    }
+}

--- a/src/main/java/com/backend/komeet/service/reply/ReplyLikeService.java
+++ b/src/main/java/com/backend/komeet/service/reply/ReplyLikeService.java
@@ -1,0 +1,107 @@
+package com.backend.komeet.service.reply;
+
+import com.backend.komeet.component.RedisDistributedLock;
+import com.backend.komeet.domain.Reply;
+import com.backend.komeet.exception.CustomException;
+import com.backend.komeet.repository.ReplyRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+import static com.backend.komeet.exception.ErrorCode.COMMENT_NOT_FOUND;
+
+@Slf4j
+@RequiredArgsConstructor
+@Service
+public class ReplyLikeService {
+    private final ReplyRepository replyRepository;
+    private final RedisDistributedLock redisDistributedLock;
+    final String LOCK_KEY = "likeReply : ";
+
+    /**
+     * 대댓글 좋아요를 처리하는 메서드
+     *
+     * @param userSeq  사용자 식별자
+     * @param replySeq 대댓글 식별자
+     */
+    @Async
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void likeReply(Long userSeq, Long replySeq) {
+        int maxRetries = 3;
+        int retries = 0;
+        long retryIntervalMillis = 1000; // 1초 간격으로 재시도
+        Integer likeCount = null;
+
+        while (retries <= maxRetries) {
+            try {
+                likeCount = processLike(userSeq, replySeq);
+                if (likeCount != null) {
+                    break;
+                } else {
+                    log.error("Failed to acquire lock for postSeq: {}", replySeq);
+                }
+            } catch (CustomException e) {
+                log.error(e.getMessage());
+            }
+            if (retries < maxRetries) {
+                retries++;
+                try {
+                    Thread.sleep(retryIntervalMillis);
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                }
+            }
+        }
+        if (likeCount == null) {
+            log.error("Failed to process like for postSeq {} after {} retries", replySeq, maxRetries);
+        }
+    }
+
+    /**
+     * 좋아요 작업을 처리하는 메서드
+     *
+     * @param userSeq 사용자 식별자
+     * @param replySeq 게시물 식별자
+     * @return 작업 성공 여부
+     * @throws CustomException 작업 실패
+     */
+    private Integer processLike(Long userSeq, Long replySeq) throws CustomException {
+        Reply reply = getReply(replySeq);
+
+        boolean lockAcquired = false;
+        try {
+            lockAcquired = redisDistributedLock.acquireLock(
+                    LOCK_KEY, replySeq.toString(), 10
+            );
+            if (lockAcquired) {
+                if (reply.getLikeUsers().remove(userSeq)) {
+                    reply.setUpVotes(reply.getUpVotes() - 1);
+                } else {
+                    reply.getLikeUsers().add(userSeq);
+                    reply.setUpVotes(reply.getUpVotes() + 1);
+                }
+                return replyRepository.save(reply).getUpVotes();
+            } else {
+                return null;
+            }
+        } finally {
+            if (lockAcquired) {
+                redisDistributedLock.releaseLock(LOCK_KEY, replySeq.toString());
+            }
+        }
+    }
+
+    /**
+     * 게시물 식별자로 게시물을 조회하는 메서드
+     *
+     * @param seq 게시물 식별자
+     * @return 게시물
+     */
+    private Reply getReply(Long seq) {
+        return replyRepository.findById(seq)
+                .orElseThrow(() -> new CustomException(COMMENT_NOT_FOUND));
+    }
+}


### PR DESCRIPTION
### 작업 내용
- 댓글, 대댓글 좋아요 기능 추가

### 변경 사항(추가시엔 추가사항)
- 댓글, 대댓글 좋아요 기능 추가
- 기존 게시물 좋아요 로직에서 불필요한 코드 (`CompleteableFuture`) 제거 및 로직 간소화

### 특이 사항
- 없음

### 테스트
- [x] 테스트 코드
- [x] api 테스트

### 관련 이슈(옵셔널)
- 없음