### PR TITLE
fix: 댓글DTO에 누락된 생성일 필드 추가

### DIFF
--- a/src/main/java/com/backend/komeet/dto/ReplyDto.java
+++ b/src/main/java/com/backend/komeet/dto/ReplyDto.java
@@ -30,6 +30,7 @@ public class ReplyDto {
                 .upVotes(reply.getUpVotes())
                 .downVotes(reply.getDownVotes())
                 .status(reply.getStatus())
+                .createdAt(reply.getCreatedAt())
                 .build();
     }
 }


### PR DESCRIPTION
### 작업 내용
- 댓글DTO에 누락된 생성일 필드 추가

### 변경 사항(추가시엔 추가사항)
- 댓글DTO에 누락된 생성일 필드 추가

### 특이 사항
- 없음

### 테스트
- [x] 테스트 코드
- [x] api 테스트

### 관련 이슈(옵셔널)
- 없음