### PR TITLE
fix: 채팅 조회 시 정렬 최근 순부터 반환하도록 수정

### DIFF
--- a/src/main/java/com/backend/komeet/repository/ChatQRepositoryImpl.java
+++ b/src/main/java/com/backend/komeet/repository/ChatQRepositoryImpl.java
@@ -47,7 +47,7 @@ public class ChatQRepositoryImpl implements ChatQRepository {
                 .limit(pageable.getPageSize())
                 .fetch()
                 .stream()
-                .map(chatItem -> ChatDto.from(chatItem))
+                .map(ChatDto::from)
                 .collect(Collectors.toList());
 
         return new PageImpl<>(results, pageable, total);

--- a/src/main/java/com/backend/komeet/repository/ChatQRepositoryImpl.java
+++ b/src/main/java/com/backend/komeet/repository/ChatQRepositoryImpl.java
@@ -38,7 +38,7 @@ public class ChatQRepositoryImpl implements ChatQRepository {
                                 .or(chat.recipientSeq.eq(userSeq))
                         );
         Long total = getLength(predicate);
-        OrderSpecifier<?> orderSpecifier = chat.createdAt.asc();
+        OrderSpecifier<?> orderSpecifier = chat.createdAt.desc();
 
         List<ChatDto> results = jpaQueryFactory.selectFrom(chat)
                 .where(predicate)
@@ -47,7 +47,7 @@ public class ChatQRepositoryImpl implements ChatQRepository {
                 .limit(pageable.getPageSize())
                 .fetch()
                 .stream()
-                .map(chatItem -> ChatDto.from(chatItem))
+                .map(ChatDto::from)
                 .collect(Collectors.toList());
 
         return new PageImpl<>(results, pageable, total);

--- a/src/main/java/com/backend/komeet/repository/ChatQRepositoryImpl.java
+++ b/src/main/java/com/backend/komeet/repository/ChatQRepositoryImpl.java
@@ -47,7 +47,7 @@ public class ChatQRepositoryImpl implements ChatQRepository {
                 .limit(pageable.getPageSize())
                 .fetch()
                 .stream()
-                .map(chatItem -> ChatDto.from(chatItem, userSeq))
+                .map(chatItem -> ChatDto.from(chatItem))
                 .collect(Collectors.toList());
 
         return new PageImpl<>(results, pageable, total);

--- a/src/main/java/com/backend/komeet/repository/ChatQRepositoryImpl.java
+++ b/src/main/java/com/backend/komeet/repository/ChatQRepositoryImpl.java
@@ -47,7 +47,7 @@ public class ChatQRepositoryImpl implements ChatQRepository {
                 .limit(pageable.getPageSize())
                 .fetch()
                 .stream()
-                .map(ChatDto::from)
+                .map(chatItem -> ChatDto.from(chatItem, userSeq))
                 .collect(Collectors.toList());
 
         return new PageImpl<>(results, pageable, total);


### PR DESCRIPTION
### 작업 내용
- 채팅 조회 시 정렬 최근 순부터 반환하도록 수정

### 변경 사항(추가시엔 추가사항)
- 채팅 조회 시 정렬 최근 순부터 반환하도록 수정

### 특이 사항
- 없음

### 테스트
- [x] 테스트 코드
- [x] api 테스트

### 관련 이슈(옵셔널)
- 없음