### PR TITLE
feat: 사용자 이메일 인증 기능 개선 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,9 @@ ENV CUSTOM_NAME default
 # jar 파일을 컨테이너 내부에 복사
 COPY ${JAR_FILE} ko-meet.jar
 
+# 로그 디렉토리 생성
+RUN mkdir -p /var/log/api
+
 # 외부 호스트 8080 포트로 노출
 EXPOSE 8080
 

--- a/build.gradle
+++ b/build.gradle
@@ -72,6 +72,8 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-websocket'
     //logback
     implementation 'ch.qos.logback:logback-classic:1.2.11'
+    // Thymeleaf
+    implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
 }
 
 def generatedDir =  "$buildDir/main/generated"

--- a/src/main/java/com/backend/komeet/chat/application/ChatRoomService.java
+++ b/src/main/java/com/backend/komeet/chat/application/ChatRoomService.java
@@ -1,11 +1,12 @@
 package com.backend.komeet.chat.application;
 
-import com.backend.komeet.chat.model.entities.ChatRoom;
-import com.backend.komeet.user.model.entities.User;
 import com.backend.komeet.chat.model.dtos.ChatRoomDto;
+import com.backend.komeet.chat.model.entities.ChatRoom;
+import com.backend.komeet.chat.repositories.ChatRepository;
+import com.backend.komeet.chat.repositories.ChatRoomRepository;
 import com.backend.komeet.infrastructure.exception.CustomException;
 import com.backend.komeet.infrastructure.exception.ErrorCode;
-import com.backend.komeet.chat.repositories.ChatRoomRepository;
+import com.backend.komeet.user.model.entities.User;
 import com.backend.komeet.user.repositories.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -28,6 +29,7 @@ import static com.backend.komeet.infrastructure.exception.ErrorCode.USER_INFO_NO
 public class ChatRoomService {
     private final ChatRoomRepository chatRoomRepository;
     private final UserRepository userRepository;
+    private final ChatRepository chatRepository;
 
     /**
      * 채팅방 목록을 조회하는 메서드
@@ -174,5 +176,15 @@ public class ChatRoomService {
                 .findById(userSeq)
                 .orElseThrow(() -> new CustomException(USER_INFO_NOT_FOUND));
         return chatRoomRepository.searchChatRoomsByUserNickName(user, keyword);
+    }
+
+    /**
+     * 사용자가 읽지 않은 채팅이 있는지 확인하는 메서드
+     *
+     * @param userSeq 사용자 식별자
+     * @return 읽지 않은 채팅 여부
+     */
+    public boolean getNewChatRooms(Long userSeq) {
+        return chatRepository.hasUnreadMessages(userSeq);
     }
 }

--- a/src/main/java/com/backend/komeet/chat/presentation/controller/ChatController.java
+++ b/src/main/java/com/backend/komeet/chat/presentation/controller/ChatController.java
@@ -1,12 +1,12 @@
 package com.backend.komeet.chat.presentation.controller;
 
-import com.backend.komeet.chat.presentation.request.ChatContentRequest;
-import com.backend.komeet.infrastructure.security.JwtProvider;
-import com.backend.komeet.chat.model.dtos.ChatDto;
-import com.backend.komeet.chat.model.dtos.ChatRoomDto;
 import com.backend.komeet.base.presentation.response.ApiResponse;
 import com.backend.komeet.chat.application.ChatRoomService;
 import com.backend.komeet.chat.application.ChatService;
+import com.backend.komeet.chat.model.dtos.ChatDto;
+import com.backend.komeet.chat.model.dtos.ChatRoomDto;
+import com.backend.komeet.chat.presentation.request.ChatContentRequest;
+import com.backend.komeet.infrastructure.security.JwtProvider;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import lombok.RequiredArgsConstructor;
@@ -135,5 +135,21 @@ public class ChatController {
         return ResponseEntity
                 .status(OK)
                 .body(new ApiResponse(chatRoomService.searchChatRooms(userSeq, keyword)));
+    }
+
+    /**
+     * 신규 채팅 여부 조회
+     *
+     * @param token 토큰
+     * @return {@link ResponseEntity<ApiResponse>} 신규 채팅 여부
+     */
+    @ApiOperation(value = "신규 채팅 여부 조회", notes = "신규 채팅 여부를 조회합니다.")
+    @GetMapping("/rooms/new")
+    public ResponseEntity<ApiResponse> getNewChatRooms(
+            @RequestHeader(AUTHORIZATION) String token) {
+        Long userSeq = jwtProvider.getIdFromToken(token);
+        return ResponseEntity
+                .status(OK)
+                .body(new ApiResponse(chatRoomService.getNewChatRooms(userSeq)));
     }
 }

--- a/src/main/java/com/backend/komeet/chat/repositories/ChatQRepository.java
+++ b/src/main/java/com/backend/komeet/chat/repositories/ChatQRepository.java
@@ -1,6 +1,7 @@
 package com.backend.komeet.chat.repositories;
 
 import com.backend.komeet.chat.model.dtos.ChatDto;
+import com.backend.komeet.user.model.entities.User;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
@@ -9,4 +10,5 @@ import org.springframework.data.domain.Pageable;
  */
 public interface ChatQRepository {
     Page<ChatDto> getChats(Long counterpartSeq, Long userSeq, Pageable pageable);
+    boolean hasUnreadMessages(Long userSeq);
 }

--- a/src/main/java/com/backend/komeet/chat/repositories/ChatQRepositoryImpl.java
+++ b/src/main/java/com/backend/komeet/chat/repositories/ChatQRepositoryImpl.java
@@ -9,7 +9,6 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
-import org.springframework.stereotype.Repository;
 
 import java.util.List;
 import java.util.stream.Collectors;
@@ -59,6 +58,24 @@ public class ChatQRepositoryImpl implements ChatQRepository {
         return new PageImpl<>(results, pageable, total);
     }
 
+    /**
+     * 사용자가 읽지 않은 채팅이 있는지 확인하는 메서드
+     *
+     * @param userSeq 사용자 식별자
+     * @return 읽지 않은 채팅 여부
+     */
+    @Override
+    public boolean hasUnreadMessages(Long userSeq) {
+        QChat chat = QChat.chat;
+        Predicate predicate = chat.recipient.seq.eq(userSeq)
+                .and(chat.readStatus.isFalse())
+                .and(chat.invisibleToRecipient.ne(userSeq)
+                        .or(chat.invisibleToRecipient.ne(userSeq)));
+
+        return jpaQueryFactory.selectFrom(chat)
+                .where(predicate)
+                .fetchCount() > 0;
+    }
     /**
      * 전체 결과 개수를 조회하는 메서드
      *

--- a/src/main/java/com/backend/komeet/notice/model/dtos/NoticeDto.java
+++ b/src/main/java/com/backend/komeet/notice/model/dtos/NoticeDto.java
@@ -26,11 +26,15 @@ public class NoticeDto {
     private List<Long> readUsers;
 
     public static NoticeDto from(Notice notice) {
+        String content = notice.getContent();
+        if (content.length() > 30) {
+            content = content.substring(0, 30);
+        }
         return NoticeDto.builder()
                 .seq(notice.getSeq())
                 .authorUserSeq(notice.getAuthorUserSeq())
                 .title(notice.getTitle())
-                .content(notice.getContent())
+                .content(content + "...")
                 .type(notice.getType())
                 .status(notice.getStatus())
                 .targetCountries(notice.getTargetCountries())

--- a/src/main/java/com/backend/komeet/notice/presentation/controller/NoticeController.java
+++ b/src/main/java/com/backend/komeet/notice/presentation/controller/NoticeController.java
@@ -14,6 +14,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import static com.backend.komeet.post.enums.PostStatus.DELETED;
+import static org.springframework.http.HttpHeaders.AUTHORIZATION;
 import static org.springframework.http.HttpStatus.NO_CONTENT;
 import static org.springframework.http.HttpStatus.OK;
 
@@ -21,7 +22,7 @@ import static org.springframework.http.HttpStatus.OK;
  * 공지사항 관련 컨트롤러
  */
 @Api(tags = "Notice API", description = "공지사항 관련 API")
-@RequestMapping("/api/v1/notices/")
+@RequestMapping("/api/v1/notices")
 @RequiredArgsConstructor
 @RestController
 public class NoticeController {
@@ -33,7 +34,7 @@ public class NoticeController {
     @PostMapping
     @ApiOperation(value = "공지사항 등록", notes = "공지사항을 등록합니다.")
     public ResponseEntity<ApiResponse> registerNotice(@RequestBody NoticeRegisterRequest request,
-                                                      @RequestHeader String token) {
+                                                      @RequestHeader(AUTHORIZATION) String token) {
         Long userSeq = jwtProvider.getIdFromToken(token);
         noticeRegisterService.registerNotice(userSeq, request);
         return ResponseEntity
@@ -43,7 +44,7 @@ public class NoticeController {
 
     @GetMapping
     @ApiOperation(value = "공지사항 조회", notes = "공지사항을 조회합니다.")
-    public ResponseEntity<ApiResponse> getNotices(@RequestHeader String token,
+    public ResponseEntity<ApiResponse> getNotices(@RequestHeader(AUTHORIZATION) String token,
                                                   @RequestParam Integer page) {
         Long userSeq = jwtProvider.getIdFromToken(token);
         return ResponseEntity
@@ -55,7 +56,7 @@ public class NoticeController {
 
     @GetMapping("/{noticeSeq}")
     @ApiOperation(value = "공지사항 상세 조회", notes = "공지사항을 상세 조회합니다.")
-    public ResponseEntity<ApiResponse> getNotice(@RequestHeader String token,
+    public ResponseEntity<ApiResponse> getNotice(@RequestHeader(AUTHORIZATION) String token,
                                                  @PathVariable Long noticeSeq) {
         Long userSeq = jwtProvider.getIdFromToken(token);
         return ResponseEntity
@@ -67,7 +68,7 @@ public class NoticeController {
 
     @PatchMapping("/{noticeSeq}")
     @ApiOperation(value = "공지사항 수정", notes = "공지사항을 수정합니다.")
-    public ResponseEntity<Void> modifyNotice(@RequestHeader String token,
+    public ResponseEntity<Void> modifyNotice(@RequestHeader(AUTHORIZATION) String token,
                                              @PathVariable Long noticeSeq,
                                              @RequestBody NoticeModifyRequest request) {
         Long userSeq = jwtProvider.getIdFromToken(token);
@@ -77,7 +78,7 @@ public class NoticeController {
 
     @PatchMapping("/{noticeSeq}/delete")
     @ApiOperation(value = "공지사항 삭제", notes = "공지사항을 삭제합니다.")
-    public ResponseEntity<Void> deleteNotice(@RequestHeader String token,
+    public ResponseEntity<Void> deleteNotice(@RequestHeader(AUTHORIZATION) String token,
                                              @PathVariable Long noticeSeq) {
         Long userSeq = jwtProvider.getIdFromToken(token);
         noticeModifyService.modifyNotice(

--- a/src/main/java/com/backend/komeet/notice/repositories/NoticeQRepositoryImpl.java
+++ b/src/main/java/com/backend/komeet/notice/repositories/NoticeQRepositoryImpl.java
@@ -3,6 +3,7 @@ package com.backend.komeet.notice.repositories;
 import com.backend.komeet.notice.model.dtos.NoticeDto;
 import com.backend.komeet.notice.model.entities.QNotice;
 import com.backend.komeet.post.enums.PostStatus;
+import com.backend.komeet.user.enums.Countries;
 import com.backend.komeet.user.model.entities.User;
 import com.querydsl.core.BooleanBuilder;
 import com.querydsl.core.types.Predicate;
@@ -17,6 +18,7 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 import static com.backend.komeet.post.enums.PostStatus.*;
+import static com.backend.komeet.user.enums.Countries.*;
 
 @RequiredArgsConstructor
 public class NoticeQRepositoryImpl implements NoticeQRepository {
@@ -37,9 +39,8 @@ public class NoticeQRepositoryImpl implements NoticeQRepository {
 
             BooleanBuilder predicateBuilder = new BooleanBuilder();
 
-
-            predicateBuilder.and(notice.readUsers.contains(user.getSeq()).not());
-            predicateBuilder.and(notice.targetCountries.contains(user.getCountry()));
+            predicateBuilder.and(notice.targetCountries.contains(user.getCountry())
+                    .or(notice.targetCountries.contains(ALL)));
             predicateBuilder.and(notice.status.eq(NORMAL));
 
             Long total = getTotal(predicateBuilder.getValue());

--- a/src/main/java/com/backend/komeet/user/application/UserInformationService.java
+++ b/src/main/java/com/backend/komeet/user/application/UserInformationService.java
@@ -65,9 +65,6 @@ public class UserInformationService {
         if (userInfoUpdateRequest.getProfileImage() != null) {
             user.setImageUrl(userInfoUpdateRequest.getProfileImage());
         }
-        if (userInfoUpdateRequest.getProfileImage() != null) {
-            user.setImageUrl(userInfoUpdateRequest.getProfileImage());
-        }
         if (userInfoUpdateRequest.getStatus() != null) {
             user.setUserStatus(userInfoUpdateRequest.getStatus());
         }

--- a/src/main/java/com/backend/komeet/user/presentation/controller/EmailVerificationController.java
+++ b/src/main/java/com/backend/komeet/user/presentation/controller/EmailVerificationController.java
@@ -1,0 +1,38 @@
+package com.backend.komeet.user.presentation.controller;
+
+import com.backend.komeet.user.application.UserSignUpService;
+import io.swagger.annotations.ApiOperation;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.util.Pair;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+/**
+ * 위치 관련 컨트롤러
+ */
+@RequestMapping("/api/v1/users")
+@RequiredArgsConstructor
+@Controller
+public class EmailVerificationController {
+    private final UserSignUpService userSignUpService;
+
+    /**
+     * 사용자 이메일 인증
+     *
+     * @param userSeq 사용자 시퀀스
+     * @return ResponseEntity<Void>
+     */
+    @GetMapping("/{userSeq}/verification")
+    @ApiOperation(value = "사용자 이메일 인증", notes = "사용자 이메일 인증 진행")
+    public String verifyEmail(@PathVariable Long userSeq,
+                              Model model) {
+        Pair<String,Boolean> result = userSignUpService.verifyEmail(userSeq);
+        model.addAttribute("message", result.getFirst());
+        model.addAttribute("isLoginAvailable", result.getSecond());
+        return "verification-result";
+    }
+
+}

--- a/src/main/java/com/backend/komeet/user/presentation/controller/UserController.java
+++ b/src/main/java/com/backend/komeet/user/presentation/controller/UserController.java
@@ -4,7 +4,6 @@ import com.backend.komeet.base.presentation.response.ApiResponse;
 import com.backend.komeet.infrastructure.security.JwtProvider;
 import com.backend.komeet.user.application.*;
 import com.backend.komeet.user.enums.EmailComponents;
-import com.backend.komeet.user.enums.UserStatus;
 import com.backend.komeet.user.model.dtos.UserDto;
 import com.backend.komeet.user.model.dtos.UserSignInDto;
 import com.backend.komeet.user.presentation.request.*;
@@ -18,7 +17,7 @@ import org.springframework.web.bind.annotation.*;
 import javax.validation.Valid;
 import java.util.concurrent.CompletableFuture;
 
-import static com.backend.komeet.user.enums.UserStatus.*;
+import static com.backend.komeet.user.enums.UserStatus.ACTIVE;
 import static com.backend.komeet.user.enums.UserStatus.BLOCKED;
 import static org.springframework.http.HttpHeaders.AUTHORIZATION;
 import static org.springframework.http.HttpStatus.*;
@@ -91,21 +90,6 @@ public class UserController {
         );
 
         return ResponseEntity.status(CREATED).build();
-    }
-
-    /**
-     * 사용자 이메일 인증
-     *
-     * @param userSeq 사용자 시퀀스
-     * @return ResponseEntity<Void>
-     */
-    @GetMapping("/{userSeq}/verification")
-    @ApiOperation(value = "사용자 이메일 인증", notes = "사용자 이메일 인증 진행")
-    public ResponseEntity<ApiResponse> verifyEmail(@PathVariable Long userSeq) {
-
-        userSignUpService.verifyEmail(userSeq);
-
-        return ResponseEntity.status(OK).build();
     }
 
     /**

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -13,10 +13,11 @@
     <!-- File Appender -->
     <appender name="FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
         <!-- Corrected: Specify the full path including the file name for the 'file' property -->
-        <file>${user.home}/kather/logs/app.log</file>
+        <file>/var/log/api/app.log</file>
         <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
             <!-- daily rollover with path fixed in the pattern -->
-            <fileNamePattern>${user.home}/kather/logs/application.%d{yyyy-MM-dd}.log</fileNamePattern>
+            <fileNamePattern>/var/log/api/application.%d{yyyy-MM-dd}
+                .log</fileNamePattern>
             <!-- keep 30 days' worth of history -->
             <maxHistory>30</maxHistory>
         </rollingPolicy>

--- a/src/main/resources/templates/verification-result.html
+++ b/src/main/resources/templates/verification-result.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html lang="en" xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8">
+    <meta content="width=device-width, initial-scale=1.0" name="viewport">
+    <title>회원가입 완료</title>
+    <style>
+        body {
+            font-family: Arial, sans-serif;
+            display: flex;
+            flex-direction: column;
+            align-items: center;
+            justify-content: center;
+            height: 100vh;
+            margin: 0;
+            padding: 0 30px;
+        }
+
+        .message {
+            font-size: 18px;
+            text-align: center;
+            margin: -18px 0 20px;
+        }
+
+        .message p {
+            margin: 18px 0;
+        }
+    </style>
+</head>
+<body>
+<div class="message">
+    <p th:text="${message}"></p>
+    <p th:if="${isLoginAvailable}">앱에서 로그인을 진행해주세요.</p>
+</div>
+</body>
+</html>


### PR DESCRIPTION
### 작업 내용
- 사용자 이메일 인증 기능 개선 
### 변경 사항(추가시엔 추가사항)
- as-is : 사용자 인증 api 호출 후 응답 json이 사용자에게 그대로 노출
- to-be: thymeleaf를 이용해 인증완료 화면을 노출, 앱에서 다시 로그인을 유도 하는 메세지 전달
### 특이 사항
- 없음

### 테스트
- [x] 테스트 코드
- [x] api 테스트

### 관련 이슈(옵셔널)
- 없음