### PR TITLE
feat: 읽지 않은 공지사항 여부 반환하는 기능 추가

### DIFF
--- a/src/main/java/com/backend/komeet/notice/application/NoticeInquiryService.java
+++ b/src/main/java/com/backend/komeet/notice/application/NoticeInquiryService.java
@@ -55,6 +55,20 @@ public class NoticeInquiryService {
     }
 
     /**
+     * 공지사항 존재 여부 확인
+     *
+     * @param userSeq 사용자 고유번호
+     * @return 공지사항 존재 여부
+     */
+    @Transactional(readOnly = true)
+    public Boolean isNoticeExist(Long userSeq) {
+        User user = getUser(userSeq);
+        return noticeRepository.existsByTargetCountriesContainingAndReadUsersNotContaining(
+                user.getCountry(), user.getSeq()
+        );
+    }
+
+    /**
      * 공지사항 조회시 읽은 사용자 추가
      *
      * @param userSeq 사용자 고유번호

--- a/src/main/java/com/backend/komeet/notice/presentation/controller/NoticeController.java
+++ b/src/main/java/com/backend/komeet/notice/presentation/controller/NoticeController.java
@@ -89,4 +89,13 @@ public class NoticeController {
         return ResponseEntity.status(NO_CONTENT).build();
     }
 
+    @GetMapping("/unread")
+    @ApiOperation(value = "공지사항 존재 여부 조회", notes = "공지사항이 존재하는지 여부를 조회합니다.")
+    public ResponseEntity<ApiResponse> isNoticeExist(@RequestHeader(AUTHORIZATION) String token) {
+        Long userSeq = jwtProvider.getIdFromToken(token);
+        return ResponseEntity
+                .status(OK)
+                .body(new ApiResponse(noticeInquiryService.isNoticeExist(userSeq)));
+    }
+
 }

--- a/src/main/java/com/backend/komeet/notice/repositories/NoticeRepository.java
+++ b/src/main/java/com/backend/komeet/notice/repositories/NoticeRepository.java
@@ -1,6 +1,7 @@
 package com.backend.komeet.notice.repositories;
 
 import com.backend.komeet.notice.model.entities.Notice;
+import com.backend.komeet.user.enums.Countries;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
@@ -8,6 +9,7 @@ import org.springframework.stereotype.Repository;
  * 공지사항 레포지토리
  */
 @Repository
-public interface NoticeRepository
-        extends JpaRepository<Notice, Long>, NoticeQRepository {
+public interface NoticeRepository extends JpaRepository<Notice, Long>, NoticeQRepository {
+    Boolean existsByTargetCountriesContainingAndReadUsersNotContaining(Countries country,
+                                                                       Long seq);
 }


### PR DESCRIPTION
### 작업 내용
- 읽지 않은 공지사항 여부 반환하는 기능 추가

### 변경 사항(추가시엔 추가사항)
- 읽지 않은 공지사항 여부 받아 홈화면 내 알림아이콘 뱃지 노출 여부에 활용 

### 특이 사항
- 프론트엔드 작업필요

### 테스트
- [x] 테스트 코드
- [x] api 테스트

### 관련 이슈(옵셔널)
- 없음