### PR TITLE
feat (user) : 토큰으로 사용자 정보 조회하는 기능 추가 (#204)

### DIFF
--- a/src/main/java/com/backend/immilog/global/application/RedisService.java
+++ b/src/main/java/com/backend/immilog/global/application/RedisService.java
@@ -1,0 +1,40 @@
+package com.backend.immilog.global.application;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+import org.springframework.stereotype.Service;
+
+import static java.util.concurrent.TimeUnit.MINUTES;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class RedisService {
+    private final RedisTemplate<String, String> stringRedisTemplate;
+
+    public void saveKeyAndValue(
+            String key,
+            String value,
+            int expireTime
+    ) {
+        ValueOperations<String, String> ops = stringRedisTemplate.opsForValue();
+        ops.set(key, value);
+        stringRedisTemplate.expire(key, expireTime, MINUTES);
+    }
+
+    public String getValueByKey(
+            String refreshToken
+    ) {
+        ValueOperations<String, String> ops = stringRedisTemplate.opsForValue();
+        return ops.get(refreshToken);
+    }
+
+    public void deleteValueByKey(
+            String refreshToken
+    ) {
+        stringRedisTemplate.delete(refreshToken);
+    }
+}
+

--- a/src/main/java/com/backend/immilog/user/application/LocationService.java
+++ b/src/main/java/com/backend/immilog/user/application/LocationService.java
@@ -14,6 +14,7 @@ import org.springframework.web.client.RestTemplate;
 import java.io.IOException;
 import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
 
 /**
  * Geocoder API를 사용하여 위도와 경도를 기반으로 국가와 도시를 추출하는 서비스
@@ -78,5 +79,14 @@ public class LocationService {
             log.error("JSON 파싱 중 예외 발생", e);
         }
         return null;
+    }
+
+    public Pair<String, String> joinCompletableFutureLocation(
+            CompletableFuture<Pair<String, String>> countryFuture
+    ) {
+        return countryFuture
+                .orTimeout(5, TimeUnit.SECONDS) // 5초 이내에 완료되지 않으면 타임아웃
+                .exceptionally(throwable -> Pair.of("Error", "Timeout"))
+                .join();
     }
 }

--- a/src/main/java/com/backend/immilog/user/application/UserInformationService.java
+++ b/src/main/java/com/backend/immilog/user/application/UserInformationService.java
@@ -1,0 +1,72 @@
+package com.backend.immilog.user.application;
+
+import com.backend.immilog.global.application.RedisService;
+import com.backend.immilog.global.exception.CustomException;
+import com.backend.immilog.global.model.TokenIssuanceDTO;
+import com.backend.immilog.global.security.JwtProvider;
+import com.backend.immilog.user.enums.Countries;
+import com.backend.immilog.user.infrastructure.UserRepository;
+import com.backend.immilog.user.model.dtos.UserSignInDTO;
+import com.backend.immilog.user.model.entities.User;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.util.Pair;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import static com.backend.immilog.global.exception.ErrorCode.USER_NOT_FOUND;
+
+@Slf4j
+@RequiredArgsConstructor
+@Service
+public class UserInformationService {
+    private final UserRepository userRepository;
+    private final JwtProvider jwtProvider;
+    private final RedisService redisService;
+
+    final int REFRESH_TOKEN_EXPIRE_TIME = 5 * 29 * 24 * 60;
+    final String TOKEN_PREFIX = "Refresh: ";
+
+    @Transactional(readOnly = true)
+    public UserSignInDTO getUserSignInDTO(
+            Long userSeq,
+            Pair<String, String> country
+    ) {
+        User user = getUser(userSeq);
+        boolean isLocationMatch = isLocationMatch(user, country);
+
+        String accessToken =
+                jwtProvider.issueAccessToken(TokenIssuanceDTO.of(user));
+
+        String refreshToken = jwtProvider.issueRefreshToken();
+
+        redisService.saveKeyAndValue(
+                TOKEN_PREFIX + refreshToken, user.getEmail(),
+                REFRESH_TOKEN_EXPIRE_TIME
+        );
+
+        return UserSignInDTO.of(
+                user,
+                accessToken,
+                refreshToken,
+                isLocationMatch
+        );
+    }
+
+    private User getUser(
+            Long userSeq
+    ) {
+        return userRepository.findById(userSeq)
+                .orElseThrow(() -> new CustomException(USER_NOT_FOUND));
+    }
+
+    private static boolean isLocationMatch(
+            User user,
+            Pair<String, String> countryPair
+    ) {
+        Countries country = user.getLocation().getCountry();
+        String region = user.getLocation().getRegion();
+        return country.getCountryKoreanName().equals(countryPair.getFirst()) &&
+                region.equals(countryPair.getSecond());
+    }
+}

--- a/src/main/java/com/backend/immilog/user/application/UserSignInService.java
+++ b/src/main/java/com/backend/immilog/user/application/UserSignInService.java
@@ -1,0 +1,106 @@
+package com.backend.immilog.user.application;
+
+import com.backend.immilog.global.application.RedisService;
+import com.backend.immilog.global.exception.CustomException;
+import com.backend.immilog.global.model.TokenIssuanceDTO;
+import com.backend.immilog.global.security.JwtProvider;
+import com.backend.immilog.user.enums.UserStatus;
+import com.backend.immilog.user.infrastructure.UserRepository;
+import com.backend.immilog.user.model.dtos.UserSignInDTO;
+import com.backend.immilog.user.model.embeddables.Location;
+import com.backend.immilog.user.model.entities.User;
+import com.backend.immilog.user.presentation.request.UserSignInRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.util.Pair;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+
+import static com.backend.immilog.global.exception.ErrorCode.*;
+
+@RequiredArgsConstructor
+@Service
+public class UserSignInService {
+    private final UserRepository userRepository;
+    private final PasswordEncoder passwordEncoder;
+    private final JwtProvider jwtProvider;
+    private final RedisService redisService;
+
+    final int REFRESH_TOKEN_EXPIRE_TIME = 5 * 29 * 24 * 60;
+    final String TOKEN_PREFIX = "Refresh: ";
+
+    @Transactional
+    public UserSignInDTO signIn(
+            UserSignInRequest userSignInRequest,
+            CompletableFuture<Pair<String, String>> country
+    ) {
+        User user = getUserByEmail(userSignInRequest.getEmail());
+        validateIfPasswordsMatches(userSignInRequest, user);
+        validateIfUserStateIsActive(user);
+        String accessToken = jwtProvider.issueAccessToken(TokenIssuanceDTO.of(user));
+        String refreshToken = jwtProvider.issueRefreshToken();
+
+        redisService.saveKeyAndValue(
+                TOKEN_PREFIX + refreshToken, user.getEmail(),
+                REFRESH_TOKEN_EXPIRE_TIME
+        );
+
+        Pair<String, String> countryAndRegionPair = fetchLocation(country);
+
+        return UserSignInDTO.of(
+                user,
+                accessToken,
+                refreshToken,
+                isLocationMatch(user, countryAndRegionPair)
+        );
+    }
+
+    private static Pair<String, String> fetchLocation(
+            CompletableFuture<Pair<String, String>> country
+    ) {
+        return country
+                .orTimeout(5, TimeUnit.SECONDS) // 5초 이내에 완료되지 않으면 타임아웃
+                .exceptionally(throwable -> Pair.of("Error", "Timeout"))
+                .join();
+    }
+
+    private static boolean isLocationMatch(
+            User user,
+            Pair<String, String> countryPair
+    ) {
+        Location location = user.getLocation();
+        String country = location.getCountry().getCountryName();
+        String region = location.getRegion();
+        return country.equals(countryPair.getFirst()) &&
+                region.equals(countryPair.getSecond());
+    }
+
+    private static void validateIfUserStateIsActive(
+            User user
+    ) {
+        if (!user.getUserStatus().equals(UserStatus.ACTIVE)) {
+            throw new CustomException(USER_STATUS_NOT_ACTIVE);
+        }
+    }
+
+    private void validateIfPasswordsMatches(
+            UserSignInRequest userSignInRequest,
+            User user
+    ) {
+        if (!passwordEncoder.matches(userSignInRequest.getPassword(), user.getPassword())) {
+            throw new CustomException(PASSWORD_NOT_MATCH);
+        }
+    }
+
+    private User getUserByEmail(
+            String email
+    ) {
+        return userRepository
+                .findByEmail(email)
+                .orElseThrow(() -> new CustomException(USER_NOT_FOUND));
+    }
+
+}

--- a/src/main/java/com/backend/immilog/user/model/dtos/UserSignInDTO.java
+++ b/src/main/java/com/backend/immilog/user/model/dtos/UserSignInDTO.java
@@ -1,0 +1,49 @@
+package com.backend.immilog.user.model.dtos;
+
+import com.backend.immilog.user.model.entities.User;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class UserSignInDTO {
+    private Long userSeq;
+    private String email;
+    private String nickname;
+    private String accessToken;
+    private String refreshToken;
+    private String country;
+    private String interestCountry;
+    private String region;
+    private String userProfileUrl;
+    private Boolean isLocationMatch;
+
+    public static UserSignInDTO of(
+            User user,
+            String accessToken,
+            String refreshToken,
+            boolean isLocationMatch
+    ) {
+        String interestCountry =
+                user.getInterestCountry() == null ? null :
+                        user.getInterestCountry().getCountryName();
+
+        return UserSignInDTO.builder()
+                .userSeq(user.getSeq())
+                .email(user.getEmail())
+                .nickname(user.getNickName())
+                .accessToken(accessToken == null ? "" : accessToken)
+                .refreshToken(refreshToken == null ? "" : refreshToken)
+                .country(user.getLocation().getCountry().getCountryName())
+                .interestCountry(interestCountry)
+                .region(user.getLocation().getRegion())
+                .userProfileUrl(user.getImageUrl())
+                .isLocationMatch(isLocationMatch)
+                .build();
+    }
+}
+

--- a/src/main/java/com/backend/immilog/user/presentation/controller/AuthController.java
+++ b/src/main/java/com/backend/immilog/user/presentation/controller/AuthController.java
@@ -1,0 +1,53 @@
+package com.backend.immilog.user.presentation.controller;
+
+import com.backend.immilog.global.presentation.response.ApiResponse;
+import com.backend.immilog.global.security.JwtProvider;
+import com.backend.immilog.user.application.LocationService;
+import com.backend.immilog.user.application.UserInformationService;
+import com.backend.immilog.user.model.dtos.UserSignInDTO;
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.util.Pair;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.concurrent.CompletableFuture;
+
+import static org.apache.http.HttpHeaders.AUTHORIZATION;
+import static org.springframework.http.HttpStatus.OK;
+
+@Api(tags = "Auth API", description = "인증 관련 API")
+@RequestMapping("/api/v1/auth")
+@RequiredArgsConstructor
+@RestController
+public class AuthController {
+    private final JwtProvider jwtProvider;
+    private final LocationService locationService;
+    private final UserInformationService userInformationService;
+
+    @GetMapping("/user")
+    @ApiOperation(value = "사용자 정보 조회", notes = "사용자 정보 조회 진행")
+    public ResponseEntity<ApiResponse> getUser(
+            @RequestHeader(AUTHORIZATION) String token,
+            @RequestParam("latitude") Double latitude,
+            @RequestParam("longitude") Double longitude
+    ) {
+        CompletableFuture<Pair<String, String>> countryFuture =
+                locationService.getCountry(latitude, longitude);
+
+        Pair<String, String> country =
+                locationService.joinCompletableFutureLocation(countryFuture);
+
+        Long userSeq = jwtProvider.getIdFromToken(token);
+
+        UserSignInDTO userSignInDTO =
+                userInformationService.getUserSignInDTO(userSeq, country);
+
+        return ResponseEntity
+                .status(OK)
+                .body(new ApiResponse(userSignInDTO));
+    }
+
+}
+

--- a/src/main/java/com/backend/immilog/user/presentation/request/UserSignInRequest.java
+++ b/src/main/java/com/backend/immilog/user/presentation/request/UserSignInRequest.java
@@ -1,0 +1,29 @@
+package com.backend.immilog.user.presentation.request;
+
+import io.swagger.annotations.ApiModel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.validation.constraints.Email;
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.Size;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+@ApiModel(value = "UserSignInRequest", description = "사용자 로그인 요청 DTO")
+public class UserSignInRequest {
+    @NotBlank(message = "이메일을 입력해주세요.")
+    @Email(message = "이메일 형식에 맞게 입력해주세요.")
+    private String email;
+
+    @Size(min = 8, max = 15, message = "비밀번호는 8자에서 15자여야 합니다.")
+    @NotBlank(message = "비밀번호를 입력해주세요.")
+    private String password;
+
+    private Double latitude;
+    private Double longitude;
+}

--- a/src/test/java/com/backend/immilog/global/application/RedisServiceTest.java
+++ b/src/test/java/com/backend/immilog/global/application/RedisServiceTest.java
@@ -1,0 +1,71 @@
+package com.backend.immilog.global.application;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.*;
+
+@DisplayName("Redis 키/값 테스트")
+class RedisServiceTest {
+    @Mock
+    private RedisTemplate<String, String> stringRedisTemplate;
+    private RedisService redisService;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+        redisService = new RedisService(stringRedisTemplate);
+    }
+
+    @Test
+    @DisplayName("키/값 저장")
+    void saveKeyAndValue() {
+        // given
+        String key = "key";
+        String value = "value";
+        int expireTime = 10;
+        ValueOperations<String, String> ops =
+                mock(ValueOperations.class);
+        when(stringRedisTemplate.opsForValue())
+                .thenReturn(ops);
+        // when
+        redisService.saveKeyAndValue(key, value, expireTime);
+        // then
+        verify(ops).set(key, value);
+    }
+
+    @Test
+    @DisplayName("키로 값 가져오기")
+    void getValueByKey() {
+        // given
+        String key = "key";
+        String value = "value";
+        ValueOperations<String, String> ops =
+                mock(ValueOperations.class);
+        when(stringRedisTemplate.opsForValue())
+                .thenReturn(ops);
+        when(ops.get(key))
+                .thenReturn(value);
+        // when
+        String result = redisService.getValueByKey(key);
+        // then
+        assertThat(result).isEqualTo(value);
+    }
+
+    @Test
+    @DisplayName("키로 값 삭제")
+    void deleteValueByKey() {
+        // given
+        String key = "key";
+        // when
+        redisService.deleteValueByKey(key);
+        // then
+        verify(stringRedisTemplate).delete(key);
+    }
+}

--- a/src/test/java/com/backend/immilog/user/application/LocationServiceTest.java
+++ b/src/test/java/com/backend/immilog/user/application/LocationServiceTest.java
@@ -114,4 +114,18 @@ class LocationServiceTest {
         // then
         assertThat(resultFuture.join().getFirst()).isEqualTo("기타 국가");
     }
+
+    @Test
+    @DisplayName("CompletableFuture 객체 합치기")
+    void joinCompletableFutureLocation() {
+        // given
+        Pair<String, String> location = Pair.of("KR", "South Korea");
+        CompletableFuture<Pair<String, String>> value = CompletableFuture.completedFuture(location);
+
+        // when
+        Pair<String, String> result = locationService.joinCompletableFutureLocation(value);
+
+        // then
+        assertThat(result).isEqualTo(location);
+    }
 }

--- a/src/test/java/com/backend/immilog/user/application/UserDetailsServiceImplTest.java
+++ b/src/test/java/com/backend/immilog/user/application/UserDetailsServiceImplTest.java
@@ -1,0 +1,49 @@
+package com.backend.immilog.user.application;
+
+import com.backend.immilog.user.infrastructure.UserRepository;
+import com.backend.immilog.user.model.entities.User;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import java.util.Optional;
+
+import static com.backend.immilog.user.enums.UserRole.ROLE_USER;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+@DisplayName("UserDetailsService 테스트")
+class UserDetailsServiceImplTest {
+
+    @Mock
+    private UserRepository userRepository;
+    private UserDetailsServiceImpl userDetailsService;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+        userDetailsService = new UserDetailsServiceImpl(userRepository);
+    }
+
+    @Test
+    @DisplayName("유저 정보 가져오기")
+    void loadUserByUsername() {
+        // given
+        String email = "test@email.com";
+        User user = User.builder()
+                .email(email)
+                .password("password")
+                .userRole(ROLE_USER)
+                .build();
+
+        when(userRepository.findByEmail(email)).thenReturn(Optional.of(user));
+        // when
+        UserDetails userDetails = userDetailsService.loadUserByUsername(email);
+        // then
+        assertThat(userDetails).isNotNull();
+    }
+
+}

--- a/src/test/java/com/backend/immilog/user/application/UserInformationServiceTest.java
+++ b/src/test/java/com/backend/immilog/user/application/UserInformationServiceTest.java
@@ -1,0 +1,109 @@
+package com.backend.immilog.user.application;
+
+import com.backend.immilog.global.application.RedisService;
+import com.backend.immilog.global.security.JwtProvider;
+import com.backend.immilog.user.enums.UserStatus;
+import com.backend.immilog.user.infrastructure.UserRepository;
+import com.backend.immilog.user.model.dtos.UserSignInDTO;
+import com.backend.immilog.user.model.embeddables.Location;
+import com.backend.immilog.user.model.entities.User;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.data.util.Pair;
+
+import java.util.Optional;
+
+import static com.backend.immilog.user.enums.Countries.MALAYSIA;
+import static com.backend.immilog.user.enums.Countries.SOUTH_KOREA;
+import static com.backend.immilog.user.enums.UserRole.ROLE_USER;
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@DisplayName("사용자 정보 서비스 테스트")
+class UserInformationServiceTest {
+    @Mock
+    private UserRepository userRepository;
+    @Mock
+    private JwtProvider jwtProvider;
+    @Mock
+    private RedisService redisService;
+    private UserInformationService userInformationService;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+        userInformationService = new UserInformationService(
+                userRepository,
+                jwtProvider,
+                redisService
+        );
+    }
+
+    @Test
+    @DisplayName("사용자 정보 조회 성공 : 위치 정보 일치")
+    void getUserSignInDTO_success() {
+        // given
+        Long userSeq = 1L;
+        User user = User.builder()
+                .seq(userSeq)
+                .email("test@email.com")
+                .nickName("test")
+                .imageUrl("image")
+                .userStatus(UserStatus.PENDING)
+                .userRole(ROLE_USER)
+                .interestCountry(SOUTH_KOREA)
+                .location(Location.of(SOUTH_KOREA, "Seoul"))
+                .reportInfo(null)
+                .build();
+
+        Pair<String, String> country = Pair.of("South Korea", "Seoul");
+        when(userRepository.findById(userSeq)).thenReturn(Optional.of(user));
+        when(jwtProvider.issueAccessToken(any())).thenReturn("accessToken");
+        when(jwtProvider.issueRefreshToken()).thenReturn("refreshToken");
+
+        // when
+        UserSignInDTO result = userInformationService.getUserSignInDTO(userSeq,
+                country);
+        // then
+        verify(redisService, times(1)).saveKeyAndValue(
+                "Refresh: refreshToken", user.getEmail(), 5 * 29 * 24 * 60
+        );
+        assertThat(result.getUserSeq()).isEqualTo(userSeq);
+    }
+
+    @Test
+    @DisplayName("사용자 정보 조회 성공 : 위치 정보 불 일치")
+    void getUserSignInDTO_success_location_not_match() {
+        // given
+        Long userSeq = 1L;
+        User user = User.builder()
+                .seq(userSeq)
+                .email("test@email.com")
+                .nickName("test")
+                .imageUrl("image")
+                .userStatus(UserStatus.PENDING)
+                .userRole(ROLE_USER)
+                .interestCountry(SOUTH_KOREA)
+                .location(Location.of(MALAYSIA, "KL"))
+                .reportInfo(null)
+                .build();
+
+        Pair<String, String> country = Pair.of("South Korea", "Seoul");
+        when(userRepository.findById(userSeq)).thenReturn(Optional.of(user));
+        when(jwtProvider.issueAccessToken(any())).thenReturn("accessToken");
+        when(jwtProvider.issueRefreshToken()).thenReturn("refreshToken");
+
+        // when
+        UserSignInDTO result = userInformationService.getUserSignInDTO(userSeq, country);
+        // then
+        verify(redisService, times(1)).saveKeyAndValue(
+                "Refresh: refreshToken", user.getEmail(), 5 * 29 * 24 * 60
+        );
+        assertThat(result.getUserSeq()).isEqualTo(userSeq);
+    }
+
+}

--- a/src/test/java/com/backend/immilog/user/application/UserSignInServiceTest.java
+++ b/src/test/java/com/backend/immilog/user/application/UserSignInServiceTest.java
@@ -1,0 +1,132 @@
+package com.backend.immilog.user.application;
+
+import com.backend.immilog.global.application.RedisService;
+import com.backend.immilog.global.exception.CustomException;
+import com.backend.immilog.global.model.TokenIssuanceDTO;
+import com.backend.immilog.global.security.JwtProvider;
+import com.backend.immilog.user.enums.Countries;
+import com.backend.immilog.user.enums.UserRole;
+import com.backend.immilog.user.enums.UserStatus;
+import com.backend.immilog.user.infrastructure.UserRepository;
+import com.backend.immilog.user.model.dtos.UserSignInDTO;
+import com.backend.immilog.user.model.embeddables.Location;
+import com.backend.immilog.user.model.entities.User;
+import com.backend.immilog.user.presentation.request.UserSignInRequest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.data.util.Pair;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+
+import static com.backend.immilog.global.exception.ErrorCode.USER_NOT_FOUND;
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@DisplayName("사용자 로그인 서비스 테스트")
+class UserSignInServiceTest {
+    @Mock
+    private UserRepository userRepository;
+    @Mock
+    private PasswordEncoder passwordEncoder;
+    @Mock
+    private JwtProvider jwtProvider;
+    @Mock
+    private RedisService redisService;
+    @Mock
+    private CompletableFuture<Pair<String, String>> country;
+
+    private UserSignInService userSignInService;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+        userSignInService = new UserSignInService(userRepository, passwordEncoder, jwtProvider, redisService);
+    }
+
+    @Test
+    @DisplayName("로그인 성공")
+    void sign_in_success() {
+        // given
+        UserSignInRequest userSignInRequest = UserSignInRequest.builder()
+                .email("test@email.com")
+                .password("test1234")
+                .latitude(37.1234)
+                .longitude(127.1234)
+                .build();
+
+        Location location = Location.builder()
+                .country(Countries.SOUTH_KOREA)
+                .region("서울")
+                .build();
+
+        User user = User.builder()
+                .seq(1L)
+                .email(userSignInRequest.getEmail())
+                .userStatus(UserStatus.ACTIVE)
+                .userRole(UserRole.ROLE_USER)
+                .password(passwordEncoder.encode(userSignInRequest.getPassword()))
+                .location(location)
+                .build();
+
+        when(userRepository.findByEmail(userSignInRequest.getEmail()))
+                .thenReturn(Optional.of(user));
+        when(passwordEncoder.matches(userSignInRequest.getPassword(), user.getPassword()))
+                .thenReturn(true);
+        when(jwtProvider.issueAccessToken(any(TokenIssuanceDTO.class)))
+                .thenReturn("accessToken");
+        when(jwtProvider.issueRefreshToken())
+                .thenReturn("refreshToken");
+        when(country.orTimeout(5, SECONDS))
+                .thenReturn(CompletableFuture.completedFuture(Pair.of("대한민국", "서울")));
+
+        // when
+        UserSignInDTO userSignInDTO = userSignInService.signIn(userSignInRequest, country);
+
+        // then
+        assertThat(userSignInDTO.getUserSeq()).isEqualTo(user.getSeq());
+        assertThat(userSignInDTO.getAccessToken()).isEqualTo("accessToken");
+        verify(jwtProvider, times(1)).issueAccessToken(any(TokenIssuanceDTO.class));
+        verify(jwtProvider, times(1)).issueRefreshToken();
+    }
+
+    @Test
+    @DisplayName("로그인 실패: 사용자 없음")
+    void sign_in_fail_user_not_found() {
+        // given
+        UserSignInRequest userSignInRequest = UserSignInRequest.builder()
+                .email("test@email.com")
+                .password("test1234")
+                .latitude(37.1234)
+                .longitude(127.1234)
+                .build();
+
+        Location location = Location.builder()
+                .country(Countries.SOUTH_KOREA)
+                .region("서울")
+                .build();
+
+        User user = User.builder()
+                .seq(1L)
+                .email(userSignInRequest.getEmail())
+                .userStatus(UserStatus.ACTIVE)
+                .userRole(UserRole.ROLE_USER)
+                .password(passwordEncoder.encode(userSignInRequest.getPassword()))
+                .location(location)
+                .build();
+
+        // when & then
+        assertThatThrownBy(() -> {
+            userSignInService.signIn(userSignInRequest, country);
+        })
+                .isInstanceOf(CustomException.class)
+                .hasMessage(USER_NOT_FOUND.getMessage());
+    }
+}

--- a/src/test/java/com/backend/immilog/user/presentation/controller/AuthControllerTest.java
+++ b/src/test/java/com/backend/immilog/user/presentation/controller/AuthControllerTest.java
@@ -1,0 +1,81 @@
+package com.backend.immilog.user.presentation.controller;
+
+import com.backend.immilog.global.presentation.response.ApiResponse;
+import com.backend.immilog.global.security.JwtProvider;
+import com.backend.immilog.user.application.LocationService;
+import com.backend.immilog.user.application.UserInformationService;
+import com.backend.immilog.user.model.dtos.UserSignInDTO;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.data.util.Pair;
+import org.springframework.http.ResponseEntity;
+
+import java.util.Objects;
+import java.util.concurrent.CompletableFuture;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+import static org.springframework.http.HttpStatus.OK;
+
+@DisplayName("인증 컨트롤러 테스트")
+class AuthControllerTest {
+    @Mock
+    private JwtProvider jwtProvider;
+    @Mock
+    private LocationService locationService;
+    @Mock
+    private UserInformationService userInformationService;
+    private AuthController authController;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+        authController = new AuthController(
+                jwtProvider,
+                locationService,
+                userInformationService
+        );
+    }
+
+    @Test
+    @DisplayName("사용자 정보 조회")
+    void getUser() {
+        // given
+        Long userSeq = 1L;
+        String token = "Bearer token";
+        Double latitude = 37.123456;
+        Double longitude = 126.123456;
+        UserSignInDTO userSignInDTO = UserSignInDTO.builder()
+                .userSeq(userSeq)
+                .email("test@email.com")
+                .nickname("test")
+                .accessToken("accessToken")
+                .refreshToken("refreshToken")
+                .country("South Korea")
+                .interestCountry("South Korea")
+                .region("Seoul")
+                .userProfileUrl("image")
+                .isLocationMatch(true)
+                .build();
+
+        Pair<String, String> location = Pair.of("KR", "South Korea");
+        CompletableFuture<Pair<String, String>> value =
+                CompletableFuture.completedFuture(location);
+        when(locationService.getCountry(latitude, longitude)).thenReturn(value);
+        when(locationService.joinCompletableFutureLocation(value)).thenReturn(location);
+        when(jwtProvider.getIdFromToken(token)).thenReturn(userSeq);
+        when(userInformationService.getUserSignInDTO(userSeq, location)).thenReturn(userSignInDTO);
+
+        // when
+        ResponseEntity<ApiResponse> response =
+                authController.getUser(token, latitude, longitude);
+
+        // then
+        assertThat(response.getStatusCode()).isEqualTo(OK);
+        Object data = Objects.requireNonNull(response.getBody()).getData();
+        assertThat(((UserSignInDTO) data).getEmail()).isEqualTo(userSignInDTO.getEmail());
+    }
+}


### PR DESCRIPTION
* feat (global) : Redis를 사용한 Key-Value 저장 기능 추가

* test (global) : Redis를 사용한 Key-Value 저장 테스트코드 추가

* feat (user) : 사용자 로그인 기능 추가

* test (user) : 사용자 로그인 테스트코드 추가

* feat (user) : 토큰으로 사용자 정보 조회하는 기능 추가

* test (user) : 토큰으로 사용자 정보 조회하는 테스트 코드 추가

### 작업 내용
- Redis를 사용한 Key-Value 저장 기능 추가

- Redis를 사용한 Key-Value 저장 테스트코드 추가

- 사용자 로그인 기능 추가

- 사용자 로그인 테스트코드 추가

- 토큰으로 사용자 정보 조회하는 기능 추가

- 토큰으로 사용자 정보 조회하는 테스트 코드 추가

### 특이 사항
- 없음
