### PR TITLE
refactor (global) : 서비스 인터페이스와 구현체를 분리하여 도메인 결합도 감소 및 유연성 향상 (#225)

### DIFF
--- a/src/main/java/com/backend/immilog/global/model/TokenIssuanceDTO.java
+++ b/src/main/java/com/backend/immilog/global/model/TokenIssuanceDTO.java
@@ -5,24 +5,22 @@ import com.backend.immilog.user.enums.UserRole;
 import com.backend.immilog.user.model.dtos.UserDTO;
 import com.backend.immilog.user.model.entities.User;
 import lombok.Builder;
-import lombok.Getter;
 
-@Getter
 @Builder
-public class TokenIssuanceDTO {
-    private Long id;
-    private String email;
-    private UserRole userRole;
-    private Countries country;
-
+public record TokenIssuanceDTO(
+        Long id,
+        String email,
+        UserRole userRole,
+        Countries country
+) {
     public static TokenIssuanceDTO of(
             UserDTO userDto
     ) {
         return TokenIssuanceDTO.builder()
-                .id(userDto.getSeq())
-                .email(userDto.getEmail())
-                .userRole(userDto.getUserRole())
-                .country(userDto.getCountry())
+                .id(userDto.seq())
+                .email(userDto.email())
+                .userRole(userDto.userRole())
+                .country(userDto.country())
                 .build();
     }
 

--- a/src/main/java/com/backend/immilog/global/presentation/controller/ImageController.java
+++ b/src/main/java/com/backend/immilog/global/presentation/controller/ImageController.java
@@ -34,7 +34,7 @@ public class ImageController {
 
         return ResponseEntity
                 .status(OK)
-                .body(new ApiResponse(data));
+                .body(ApiResponse.of(data));
     }
 
     @DeleteMapping
@@ -42,7 +42,7 @@ public class ImageController {
     public ResponseEntity<ApiResponse> deleteImage(
             ImageRequest imageRequest
     ) {
-        imageService.deleteFile(imageRequest.getImagePath());
+        imageService.deleteFile(imageRequest.imagePath());
         return ResponseEntity.status(NO_CONTENT).build();
     }
 }

--- a/src/main/java/com/backend/immilog/global/presentation/request/ImageRequest.java
+++ b/src/main/java/com/backend/immilog/global/presentation/request/ImageRequest.java
@@ -1,18 +1,13 @@
 package com.backend.immilog.global.presentation.request;
 
 import io.swagger.annotations.ApiModel;
-import lombok.AllArgsConstructor;
 import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
 
-@Getter
-@AllArgsConstructor
-@NoArgsConstructor
 @Builder
 @ApiModel(value = "ImageRequest", description = "이미지 요청 DTO")
-public class ImageRequest {
-    private String imageDirectory;
-    private String imagePath;
+public record ImageRequest(
+        String imageDirectory,
+        String imagePath
+) {
 }
 

--- a/src/main/java/com/backend/immilog/global/presentation/response/ApiResponse.java
+++ b/src/main/java/com/backend/immilog/global/presentation/response/ApiResponse.java
@@ -1,47 +1,25 @@
 package com.backend.immilog.global.presentation.response;
 
-import lombok.AllArgsConstructor;
 import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import org.springframework.http.HttpStatus;
 
 import java.util.List;
 
-@Getter
-@AllArgsConstructor
-@NoArgsConstructor
 @Builder
-public class ApiResponse {
-    private Integer status;
-    private String message = "success";
-    private Object data;
-    private List<Object> list;
-
-    public ApiResponse(
-            Integer status
-    ) {
-        this.status = status;
-    }
-
-    public ApiResponse(
-            Integer status,
-            String message
-    ) {
-        this.status = status;
-        this.message = message;
-    }
-
-    public ApiResponse(
+public record ApiResponse(
+        Integer status,
+        String message,
+        Object data,
+        List<Object> list
+) {
+    public static ApiResponse of(
             Object data
     ) {
-        this.status = 200;
-        this.data = data;
-    }
-
-    public ApiResponse(
-            List<Object> list
-    ) {
-        this.status = 200;
-        this.list = list;
+        return ApiResponse.builder()
+                .status(HttpStatus.OK.value())
+                .message(null)
+                .data(data)
+                .list(null)
+                .build();
     }
 }

--- a/src/main/java/com/backend/immilog/global/security/JwtProvider.java
+++ b/src/main/java/com/backend/immilog/global/security/JwtProvider.java
@@ -47,10 +47,11 @@ public class JwtProvider {
     public String issueAccessToken(
             TokenIssuanceDTO tokenTokenIssuanceDto
     ) {
-        Claims claims = Jwts.claims().setSubject(tokenTokenIssuanceDto.getId().toString());
-        claims.put("email", tokenTokenIssuanceDto.getEmail());
-        claims.put("userRole", tokenTokenIssuanceDto.getUserRole());
-        claims.put("country", tokenTokenIssuanceDto.getCountry().getCountryCode());
+        Claims claims =
+                Jwts.claims().setSubject(tokenTokenIssuanceDto.id().toString());
+        claims.put("email", tokenTokenIssuanceDto.email());
+        claims.put("userRole", tokenTokenIssuanceDto.userRole());
+        claims.put("country", tokenTokenIssuanceDto.country().getCountryCode());
 
         return buildJwt(claims);
     }

--- a/src/main/java/com/backend/immilog/post/application/PostDeleteServiceImpl.java
+++ b/src/main/java/com/backend/immilog/post/application/PostDeleteServiceImpl.java
@@ -1,13 +1,13 @@
 package com.backend.immilog.post.application;
 
 import com.backend.immilog.global.exception.CustomException;
-import com.backend.immilog.post.infrastructure.PostRepository;
-import com.backend.immilog.post.infrastructure.PostResourceRepository;
 import com.backend.immilog.post.model.entities.Post;
+import com.backend.immilog.post.model.services.PostDeleteService;
+import com.backend.immilog.post.model.repositories.PostRepository;
+import com.backend.immilog.post.model.repositories.PostResourceRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Objects;
 
@@ -18,11 +18,11 @@ import static com.backend.immilog.post.enums.PostStatus.DELETED;
 @Slf4j
 @Service
 @RequiredArgsConstructor
-public class PostDeleteService {
+public class PostDeleteServiceImpl implements PostDeleteService {
     private final PostRepository postRepository;
     private final PostResourceRepository postResourceRepository;
 
-    @Transactional
+    @Override
     public void deletePost(
             Long userId,
             Long postSeq

--- a/src/main/java/com/backend/immilog/post/application/PostInquiryServiceImpl.java
+++ b/src/main/java/com/backend/immilog/post/application/PostInquiryServiceImpl.java
@@ -2,7 +2,8 @@ package com.backend.immilog.post.application;
 
 import com.backend.immilog.post.enums.Categories;
 import com.backend.immilog.post.enums.SortingMethods;
-import com.backend.immilog.post.infrastructure.PostRepository;
+import com.backend.immilog.post.model.services.PostInquiryService;
+import com.backend.immilog.post.model.repositories.PostRepository;
 import com.backend.immilog.post.model.dtos.PostDTO;
 import com.backend.immilog.user.enums.Countries;
 import lombok.RequiredArgsConstructor;
@@ -11,15 +12,14 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
 @Slf4j
 @Service
 @RequiredArgsConstructor
-public class PostInquiryService {
+public class PostInquiryServiceImpl implements PostInquiryService {
     private final PostRepository postRepository;
 
-    @Transactional(readOnly = true)
+    @Override
     public Page<PostDTO> getPosts(
             Countries country,
             SortingMethods sortingMethod,

--- a/src/main/java/com/backend/immilog/post/application/PostInquiryServiceImpl.java
+++ b/src/main/java/com/backend/immilog/post/application/PostInquiryServiceImpl.java
@@ -1,5 +1,6 @@
 package com.backend.immilog.post.application;
 
+import com.backend.immilog.global.exception.CustomException;
 import com.backend.immilog.post.enums.Categories;
 import com.backend.immilog.post.enums.SortingMethods;
 import com.backend.immilog.post.model.services.PostInquiryService;
@@ -12,6 +13,8 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
+
+import static com.backend.immilog.global.exception.ErrorCode.POST_NOT_FOUND;
 
 @Slf4j
 @Service
@@ -36,5 +39,14 @@ public class PostInquiryServiceImpl implements PostInquiryService {
                 category,
                 pageable
         );
+    }
+
+    @Override
+    public PostDTO getPost(
+            Long postSeq
+    ) {
+        return postRepository
+                .getPost(postSeq)
+                .orElseThrow(()-> new CustomException(POST_NOT_FOUND));
     }
 }

--- a/src/main/java/com/backend/immilog/post/application/PostUpdateServiceImpl.java
+++ b/src/main/java/com/backend/immilog/post/application/PostUpdateServiceImpl.java
@@ -4,17 +4,16 @@ import com.backend.immilog.global.application.RedisDistributedLock;
 import com.backend.immilog.global.exception.CustomException;
 import com.backend.immilog.global.infrastructure.BulkInsertRepository;
 import com.backend.immilog.post.enums.ResourceType;
-import com.backend.immilog.post.infrastructure.InteractionUserRepository;
-import com.backend.immilog.post.infrastructure.PostRepository;
-import com.backend.immilog.post.infrastructure.PostResourceRepository;
+import com.backend.immilog.post.model.repositories.InteractionUserRepository;
+import com.backend.immilog.post.model.services.PostUpdateService;
+import com.backend.immilog.post.model.repositories.PostRepository;
+import com.backend.immilog.post.model.repositories.PostResourceRepository;
 import com.backend.immilog.post.model.entities.InteractionUser;
 import com.backend.immilog.post.model.entities.Post;
 import com.backend.immilog.post.presentation.request.PostUpdateRequest;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 import java.util.Objects;
@@ -28,7 +27,7 @@ import static com.backend.immilog.post.enums.ResourceType.TAG;
 @Slf4j
 @Service
 @RequiredArgsConstructor
-public class PostUpdateService {
+public class PostUpdateServiceImpl implements PostUpdateService {
     private static final String POST_TYPE = POST.toString();
     private final PostRepository postRepository;
     private final PostResourceRepository postResourceRepository;
@@ -39,7 +38,7 @@ public class PostUpdateService {
     final String LIKE_LOCK_KEY = "likePost : ";
     final String VIEW_LOCK_KEY = "viewPost : ";
 
-    @Transactional
+    @Override
     public void updatePost(
             Long userId,
             Long postSeq,
@@ -51,8 +50,7 @@ public class PostUpdateService {
         updateResources(postSeq, postUpdateRequest);
     }
 
-    @Async
-    @Transactional
+    @Override
     public void increaseViewCount(Long postSeq) {
         executeWithLock(
                 VIEW_LOCK_KEY,
@@ -65,8 +63,7 @@ public class PostUpdateService {
         );
     }
 
-    @Async
-    @Transactional
+    @Override
     public void likePost(
             Long userSeq,
             Long postSeq
@@ -125,10 +122,10 @@ public class PostUpdateService {
 
     private void updateResources(
             Long postSeq,
-            PostUpdateRequest postUpdateRequest
+            PostUpdateRequest request
     ) {
-        updateResource(postSeq, postUpdateRequest.getDeleteTags(), postUpdateRequest.getAddTags(), TAG);
-        updateResource(postSeq, postUpdateRequest.getDeleteAttachments(), postUpdateRequest.getAddAttachments(), ATTACHMENT);
+        updateResource(postSeq, request.deleteTags(), request.addTags(), TAG);
+        updateResource(postSeq, request.deleteAttachments(), request.addAttachments(), ATTACHMENT);
     }
 
     private void updateResource(
@@ -184,16 +181,16 @@ public class PostUpdateService {
 
     private void updatePostMetaData(
             Post post,
-            PostUpdateRequest postUpdateRequest
+            PostUpdateRequest request
     ) {
-        if (postUpdateRequest.getTitle() != null) {
-            post.getPostMetaData().setTitle(postUpdateRequest.getTitle());
+        if (request.title() != null) {
+            post.getPostMetaData().setTitle(request.title());
         }
-        if (postUpdateRequest.getContent() != null) {
-            post.getPostMetaData().setContent(postUpdateRequest.getContent());
+        if (request.content() != null) {
+            post.getPostMetaData().setContent(request.content());
         }
-        if (postUpdateRequest.getIsPublic() != null) {
-            post.setIsPublic(postUpdateRequest.getIsPublic() ? "Y" : "N");
+        if (request.isPublic() != null) {
+            post.setIsPublic(request.isPublic() ? "Y" : "N");
         }
     }
 

--- a/src/main/java/com/backend/immilog/post/application/PostUploadServiceImpl.java
+++ b/src/main/java/com/backend/immilog/post/application/PostUploadServiceImpl.java
@@ -2,16 +2,16 @@ package com.backend.immilog.post.application;
 
 import com.backend.immilog.global.exception.CustomException;
 import com.backend.immilog.global.infrastructure.BulkInsertRepository;
-import com.backend.immilog.post.infrastructure.PostRepository;
+import com.backend.immilog.post.model.services.PostUploadService;
+import com.backend.immilog.post.model.repositories.PostRepository;
 import com.backend.immilog.post.model.entities.Post;
 import com.backend.immilog.post.model.entities.PostResource;
 import com.backend.immilog.post.presentation.request.PostUploadRequest;
-import com.backend.immilog.user.infrastructure.UserRepository;
+import com.backend.immilog.user.model.interfaces.repositories.UserRepository;
 import com.backend.immilog.user.model.entities.User;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
 import java.sql.SQLException;
 import java.util.ArrayList;
@@ -27,12 +27,12 @@ import static com.backend.immilog.post.enums.ResourceType.TAG;
 @Slf4j
 @RequiredArgsConstructor
 @Service
-public class PostUploadService {
+public class PostUploadServiceImpl implements PostUploadService {
     private final PostRepository postRepository;
     private final UserRepository userRepository;
     private final BulkInsertRepository bulkInsertRepository;
 
-    @Transactional
+    @Override
     public void uploadPost(
             Long userSeq,
             PostUploadRequest postUploadRequest
@@ -102,11 +102,11 @@ public class PostUploadService {
             PostUploadRequest postUploadRequest,
             Long postSeq
     ) {
-        if (postUploadRequest.getTags() == null) {
+        if (postUploadRequest.tags() == null) {
             return List.of();
         }
         return postUploadRequest
-                .getTags()
+                .tags()
                 .stream()
                 .map(tag -> PostResource.of(POST, TAG, tag, postSeq))
                 .toList();
@@ -116,11 +116,11 @@ public class PostUploadService {
             PostUploadRequest postUploadRequest,
             Long postSeq
     ) {
-        if (postUploadRequest.getAttachments() == null) {
+        if (postUploadRequest.attachments() == null) {
             return List.of();
         }
         return postUploadRequest
-                .getAttachments()
+                .attachments()
                 .stream()
                 .map(url -> PostResource.of(POST, ATTACHMENT, url, postSeq))
                 .toList();

--- a/src/main/java/com/backend/immilog/post/infrastructure/PostRepository.java
+++ b/src/main/java/com/backend/immilog/post/infrastructure/PostRepository.java
@@ -1,7 +1,0 @@
-package com.backend.immilog.post.infrastructure;
-
-import com.backend.immilog.post.model.entities.Post;
-import org.springframework.data.jpa.repository.JpaRepository;
-
-public interface PostRepository extends JpaRepository<Post, Long>, PostQRepository {
-}

--- a/src/main/java/com/backend/immilog/post/infrastructure/PostRepositoryImpl.java
+++ b/src/main/java/com/backend/immilog/post/infrastructure/PostRepositoryImpl.java
@@ -6,6 +6,7 @@ import com.backend.immilog.post.model.dtos.PostDTO;
 import com.backend.immilog.post.model.entities.QInteractionUser;
 import com.backend.immilog.post.model.entities.QPost;
 import com.backend.immilog.post.model.entities.QPostResource;
+import com.backend.immilog.post.model.repositories.PostRepositoryCustom;
 import com.backend.immilog.user.enums.Countries;
 import com.querydsl.core.BooleanBuilder;
 import com.querydsl.core.types.OrderSpecifier;
@@ -27,7 +28,7 @@ import static com.querydsl.core.types.Projections.list;
 
 @RequiredArgsConstructor
 @Repository
-public class PostQRepositoryImpl implements PostQRepository {
+public class PostRepositoryImpl implements PostRepositoryCustom {
     private final JPAQueryFactory queryFactory;
 
     @Override

--- a/src/main/java/com/backend/immilog/post/infrastructure/PostResourceRepositoryImpl.java
+++ b/src/main/java/com/backend/immilog/post/infrastructure/PostResourceRepositoryImpl.java
@@ -2,6 +2,7 @@ package com.backend.immilog.post.infrastructure;
 
 import com.backend.immilog.post.enums.ResourceType;
 import com.backend.immilog.post.model.entities.QPostResource;
+import com.backend.immilog.post.model.repositories.PostResourceRepositoryCustom;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPADeleteClause;
 import com.querydsl.jpa.impl.JPAQueryFactory;
@@ -13,7 +14,7 @@ import java.util.List;
 
 @RequiredArgsConstructor
 @Repository
-public class PostResourceQRepositoryImpl implements PostResourceQRepository {
+public class PostResourceRepositoryImpl implements PostResourceRepositoryCustom {
     private final JPAQueryFactory queryFactory;
     private final EntityManager entityManager;
 

--- a/src/main/java/com/backend/immilog/post/model/dtos/CommentDTO.java
+++ b/src/main/java/com/backend/immilog/post/model/dtos/CommentDTO.java
@@ -1,4 +1,4 @@
 package com.backend.immilog.post.model.dtos;
 
-public class CommentDTO {
+public record CommentDTO() {
 }

--- a/src/main/java/com/backend/immilog/post/model/dtos/PostDTO.java
+++ b/src/main/java/com/backend/immilog/post/model/dtos/PostDTO.java
@@ -9,7 +9,9 @@ import com.backend.immilog.post.model.embeddables.PostUserData;
 import com.backend.immilog.post.model.entities.InteractionUser;
 import com.backend.immilog.post.model.entities.Post;
 import com.backend.immilog.post.model.entities.PostResource;
-import lombok.*;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -17,7 +19,6 @@ import java.util.Objects;
 
 import static com.backend.immilog.post.enums.InteractionType.BOOKMARK;
 import static com.backend.immilog.post.enums.InteractionType.LIKE;
-import static com.backend.immilog.post.enums.PostType.POST;
 import static com.backend.immilog.post.enums.ResourceType.ATTACHMENT;
 import static com.backend.immilog.post.enums.ResourceType.TAG;
 

--- a/src/main/java/com/backend/immilog/post/model/embeddables/PostMetaData.java
+++ b/src/main/java/com/backend/immilog/post/model/embeddables/PostMetaData.java
@@ -44,8 +44,8 @@ public class PostMetaData {
             String region
     ) {
         return PostMetaData.builder()
-                .title(postUploadRequest.getTitle())
-                .content(postUploadRequest.getContent())
+                .title(postUploadRequest.title())
+                .content(postUploadRequest.content())
                 .viewCount(0L)
                 .likeCount(0L)
                 .status(PostStatus.NORMAL)

--- a/src/main/java/com/backend/immilog/post/model/entities/Post.java
+++ b/src/main/java/com/backend/immilog/post/model/entities/Post.java
@@ -57,8 +57,8 @@ public class Post extends BaseDateEntity {
         return Post.builder()
                 .postUserData(postUserData)
                 .postMetaData(postMetaData)
-                .category(postUploadRequest.getCategory())
-                .isPublic(postUploadRequest.getIsPublic() ? "Y" : "N")
+                .category(postUploadRequest.category())
+                .isPublic(postUploadRequest.isPublic() ? "Y" : "N")
                 .commentCount(0L)
                 .build();
     }

--- a/src/main/java/com/backend/immilog/post/model/repositories/InteractionUserRepository.java
+++ b/src/main/java/com/backend/immilog/post/model/repositories/InteractionUserRepository.java
@@ -1,4 +1,4 @@
-package com.backend.immilog.post.infrastructure;
+package com.backend.immilog.post.model.repositories;
 
 import com.backend.immilog.post.model.entities.InteractionUser;
 import org.springframework.data.jpa.repository.JpaRepository;

--- a/src/main/java/com/backend/immilog/post/model/repositories/PostRepository.java
+++ b/src/main/java/com/backend/immilog/post/model/repositories/PostRepository.java
@@ -1,0 +1,7 @@
+package com.backend.immilog.post.model.repositories;
+
+import com.backend.immilog.post.model.entities.Post;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PostRepository extends JpaRepository<Post, Long>, PostRepositoryCustom {
+}

--- a/src/main/java/com/backend/immilog/post/model/repositories/PostRepositoryCustom.java
+++ b/src/main/java/com/backend/immilog/post/model/repositories/PostRepositoryCustom.java
@@ -7,6 +7,8 @@ import com.backend.immilog.user.enums.Countries;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
+import java.util.Optional;
+
 public interface PostRepositoryCustom {
 
     Page<PostDTO> getPosts(
@@ -16,4 +18,6 @@ public interface PostRepositoryCustom {
             Categories category,
             Pageable pageable
     );
+
+    Optional<PostDTO> getPost(Long postSeq);
 }

--- a/src/main/java/com/backend/immilog/post/model/repositories/PostRepositoryCustom.java
+++ b/src/main/java/com/backend/immilog/post/model/repositories/PostRepositoryCustom.java
@@ -1,4 +1,4 @@
-package com.backend.immilog.post.infrastructure;
+package com.backend.immilog.post.model.repositories;
 
 import com.backend.immilog.post.enums.Categories;
 import com.backend.immilog.post.model.dtos.PostDTO;
@@ -7,7 +7,7 @@ import com.backend.immilog.user.enums.Countries;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
-public interface PostQRepository {
+public interface PostRepositoryCustom {
 
     Page<PostDTO> getPosts(
             Countries country,

--- a/src/main/java/com/backend/immilog/post/model/repositories/PostResourceRepository.java
+++ b/src/main/java/com/backend/immilog/post/model/repositories/PostResourceRepository.java
@@ -1,8 +1,8 @@
-package com.backend.immilog.post.infrastructure;
+package com.backend.immilog.post.model.repositories;
 
 import com.backend.immilog.post.model.entities.PostResource;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface PostResourceRepository
-        extends JpaRepository<PostResource, Long>, PostResourceQRepository {
+        extends JpaRepository<PostResource, Long>, PostResourceRepositoryCustom {
 }

--- a/src/main/java/com/backend/immilog/post/model/repositories/PostResourceRepositoryCustom.java
+++ b/src/main/java/com/backend/immilog/post/model/repositories/PostResourceRepositoryCustom.java
@@ -1,10 +1,10 @@
-package com.backend.immilog.post.infrastructure;
+package com.backend.immilog.post.model.repositories;
 
 import com.backend.immilog.post.enums.ResourceType;
 
 import java.util.List;
 
-public interface PostResourceQRepository {
+public interface PostResourceRepositoryCustom {
     void deleteAllEntities(
             Long postSeq,
             ResourceType resourceType,

--- a/src/main/java/com/backend/immilog/post/model/services/PostDeleteService.java
+++ b/src/main/java/com/backend/immilog/post/model/services/PostDeleteService.java
@@ -1,0 +1,11 @@
+package com.backend.immilog.post.model.services;
+
+import org.springframework.transaction.annotation.Transactional;
+
+public interface PostDeleteService {
+    @Transactional
+    void deletePost(
+            Long userId,
+            Long postSeq
+    );
+}

--- a/src/main/java/com/backend/immilog/post/model/services/PostInquiryService.java
+++ b/src/main/java/com/backend/immilog/post/model/services/PostInquiryService.java
@@ -1,0 +1,19 @@
+package com.backend.immilog.post.model.services;
+
+import com.backend.immilog.post.enums.Categories;
+import com.backend.immilog.post.enums.SortingMethods;
+import com.backend.immilog.post.model.dtos.PostDTO;
+import com.backend.immilog.user.enums.Countries;
+import org.springframework.data.domain.Page;
+import org.springframework.transaction.annotation.Transactional;
+
+public interface PostInquiryService {
+    @Transactional(readOnly = true)
+    Page<PostDTO> getPosts(
+            Countries country,
+            SortingMethods sortingMethod,
+            String isPublic,
+            Categories category,
+            Integer page
+    );
+}

--- a/src/main/java/com/backend/immilog/post/model/services/PostInquiryService.java
+++ b/src/main/java/com/backend/immilog/post/model/services/PostInquiryService.java
@@ -16,4 +16,7 @@ public interface PostInquiryService {
             Categories category,
             Integer page
     );
+
+    @Transactional(readOnly = true)
+    PostDTO getPost(Long postSeq);
 }

--- a/src/main/java/com/backend/immilog/post/model/services/PostUpdateService.java
+++ b/src/main/java/com/backend/immilog/post/model/services/PostUpdateService.java
@@ -1,0 +1,25 @@
+package com.backend.immilog.post.model.services;
+
+import com.backend.immilog.post.presentation.request.PostUpdateRequest;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.transaction.annotation.Transactional;
+
+public interface PostUpdateService {
+    @Transactional
+    void updatePost(
+            Long userId,
+            Long postSeq,
+            PostUpdateRequest postUpdateRequest
+    );
+
+    @Async
+    @Transactional
+    void increaseViewCount(Long postSeq);
+
+    @Async
+    @Transactional
+    void likePost(
+            Long userSeq,
+            Long postSeq
+    );
+}

--- a/src/main/java/com/backend/immilog/post/model/services/PostUploadService.java
+++ b/src/main/java/com/backend/immilog/post/model/services/PostUploadService.java
@@ -1,0 +1,12 @@
+package com.backend.immilog.post.model.services;
+
+import com.backend.immilog.post.presentation.request.PostUploadRequest;
+import org.springframework.transaction.annotation.Transactional;
+
+public interface PostUploadService {
+    @Transactional
+    void uploadPost(
+            Long userSeq,
+            PostUploadRequest postUploadRequest
+    );
+}

--- a/src/main/java/com/backend/immilog/post/presentation/controller/PostController.java
+++ b/src/main/java/com/backend/immilog/post/presentation/controller/PostController.java
@@ -2,13 +2,13 @@ package com.backend.immilog.post.presentation.controller;
 
 import com.backend.immilog.global.presentation.response.ApiResponse;
 import com.backend.immilog.global.security.JwtProvider;
-import com.backend.immilog.post.application.PostDeleteService;
-import com.backend.immilog.post.application.PostInquiryService;
-import com.backend.immilog.post.application.PostUpdateService;
-import com.backend.immilog.post.application.PostUploadService;
 import com.backend.immilog.post.enums.Categories;
 import com.backend.immilog.post.enums.SortingMethods;
 import com.backend.immilog.post.model.dtos.PostDTO;
+import com.backend.immilog.post.model.services.PostDeleteService;
+import com.backend.immilog.post.model.services.PostInquiryService;
+import com.backend.immilog.post.model.services.PostUpdateService;
+import com.backend.immilog.post.model.services.PostUploadService;
 import com.backend.immilog.post.presentation.request.PostUpdateRequest;
 import com.backend.immilog.post.presentation.request.PostUploadRequest;
 import com.backend.immilog.user.enums.Countries;
@@ -105,7 +105,7 @@ public class PostController {
                 category,
                 page == null ? 0 : page
         );
-        return ResponseEntity.status(OK).body(new ApiResponse(posts));
+        return ResponseEntity.status(OK).body(ApiResponse.of(posts));
     }
 
 }

--- a/src/main/java/com/backend/immilog/post/presentation/controller/PostController.java
+++ b/src/main/java/com/backend/immilog/post/presentation/controller/PostController.java
@@ -108,4 +108,15 @@ public class PostController {
         return ResponseEntity.status(OK).body(ApiResponse.of(posts));
     }
 
+    @GetMapping("/{postSeq}")
+    @ApiOperation(value = "게시물 상세 조회", notes = "게시물 상세 정보를 조회합니다.")
+    public ResponseEntity<ApiResponse> getPost(
+            @PathVariable Long postSeq
+    ) {
+        PostDTO post = postInquiryService.getPost(postSeq);
+        return ResponseEntity
+                .status(OK)
+                .body(ApiResponse.of(post));
+    }
+
 }

--- a/src/main/java/com/backend/immilog/post/presentation/request/PostUpdateRequest.java
+++ b/src/main/java/com/backend/immilog/post/presentation/request/PostUpdateRequest.java
@@ -4,21 +4,18 @@ import io.swagger.annotations.ApiModel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
 
 import java.util.List;
 
-@Getter
-@AllArgsConstructor
-@NoArgsConstructor
 @Builder
 @ApiModel(value = "PostUpdateRequest", description = "게시물 수정 요청 DTO")
-public class PostUpdateRequest {
-    private String title;
-    private String content;
-    private List<String> deleteTags;
-    private List<String> addTags;
-    private List<String> deleteAttachments;
-    private List<String> addAttachments;
-    private Boolean isPublic;
+public record PostUpdateRequest(
+        String title,
+        String content,
+        List<String> deleteTags,
+        List<String> addTags,
+        List<String> deleteAttachments,
+        List<String> addAttachments,
+        Boolean isPublic
+) {
 }

--- a/src/main/java/com/backend/immilog/post/presentation/request/PostUploadRequest.java
+++ b/src/main/java/com/backend/immilog/post/presentation/request/PostUploadRequest.java
@@ -5,30 +5,19 @@ import io.swagger.annotations.ApiModel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
 
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotNull;
 import java.util.List;
 
-@Getter
-@AllArgsConstructor
-@NoArgsConstructor
 @Builder
 @ApiModel(value = "PostUploadRequest", description = "게시물 생성 요청 DTO")
-public class PostUploadRequest {
-    @NotBlank(message = "제목을 입력해주세요.")
-    private String title;
-
-    @NotBlank(message = "내용을 입력해주세요.")
-    private String content;
-
-    private List<String> tags;
-
-    private List<String> attachments;
-
-    @NotNull(message = "전체공개 여부를 입력해주세요.")
-    private Boolean isPublic;
-
-    private Categories category;
+public record PostUploadRequest(
+        @NotBlank(message = "제목을 입력해주세요.") String title,
+        @NotBlank(message = "내용을 입력해주세요.") String content,
+        List<String> tags,
+        List<String> attachments,
+        @NotNull(message = "전체공개 여부를 입력해주세요.") Boolean isPublic,
+        @NotNull(message = "카테고리를 입력해주세요.")Categories category
+) {
 }

--- a/src/main/java/com/backend/immilog/user/application/UserDetailsServiceImpl.java
+++ b/src/main/java/com/backend/immilog/user/application/UserDetailsServiceImpl.java
@@ -1,7 +1,7 @@
 package com.backend.immilog.user.application;
 
 import com.backend.immilog.global.exception.CustomException;
-import com.backend.immilog.user.infrastructure.UserRepository;
+import com.backend.immilog.user.model.interfaces.repositories.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.userdetails.User;

--- a/src/main/java/com/backend/immilog/user/application/UserInformationService.java
+++ b/src/main/java/com/backend/immilog/user/application/UserInformationService.java
@@ -7,7 +7,7 @@ import com.backend.immilog.global.model.TokenIssuanceDTO;
 import com.backend.immilog.global.security.JwtProvider;
 import com.backend.immilog.user.enums.Countries;
 import com.backend.immilog.user.enums.UserStatus;
-import com.backend.immilog.user.infrastructure.UserRepository;
+import com.backend.immilog.user.model.interfaces.repositories.UserRepository;
 import com.backend.immilog.user.model.dtos.UserSignInDTO;
 import com.backend.immilog.user.model.entities.User;
 import com.backend.immilog.user.presentation.request.UserInfoUpdateRequest;
@@ -73,10 +73,10 @@ public class UserInformationService {
     ) {
         User user = getUser(userSeq);
         setUserCountryIfItsChanged(country, userInfoUpdateRequest, user);
-        setUserNickNameIfItsChanged(userInfoUpdateRequest.getNickName(), user);
-        setUserInterestCountryIfItsChanged(userInfoUpdateRequest.getInterestCountry(), user);
-        setUserStatusIfItsChanged(userInfoUpdateRequest.getStatus(), user);
-        setUserImageProfileIfItsChanged(userInfoUpdateRequest.getProfileImage(), user);
+        setUserNickNameIfItsChanged(userInfoUpdateRequest.nickName(), user);
+        setUserInterestCountryIfItsChanged(userInfoUpdateRequest.interestCountry(), user);
+        setUserStatusIfItsChanged(userInfoUpdateRequest.status(), user);
+        setUserImageProfileIfItsChanged(userInfoUpdateRequest.profileImage(), user);
     }
 
     @Transactional
@@ -85,8 +85,8 @@ public class UserInformationService {
             UserPasswordChangeRequest userPasswordChangeRequest
     ) {
         User user = getUser(userSeq);
-        String existingPassword = userPasswordChangeRequest.getExistingPassword();
-        String newPassword = userPasswordChangeRequest.getNewPassword();
+        String existingPassword = userPasswordChangeRequest.existingPassword();
+        String newPassword = userPasswordChangeRequest.newPassword();
         String currentPassword = user.getPassword();
         throwExceptionIfPasswordNotMatch(existingPassword, currentPassword);
         user.setPassword(passwordEncoder.encode(newPassword));
@@ -126,10 +126,10 @@ public class UserInformationService {
             User user
     ) {
         try {
-            if (userInfoUpdateRequest.getCountry() != null && country.get() != null) {
+            if (userInfoUpdateRequest.country() != null && country.get() != null) {
                 Pair<String, String> countryPair = country.join();
                 user.getLocation().setRegion(countryPair.getSecond());
-                user.getLocation().setCountry(userInfoUpdateRequest.getCountry());
+                user.getLocation().setCountry(userInfoUpdateRequest.country());
             }
         } catch (InterruptedException | ExecutionException e) {
             log.info(e.getMessage());

--- a/src/main/java/com/backend/immilog/user/application/UserReportService.java
+++ b/src/main/java/com/backend/immilog/user/application/UserReportService.java
@@ -2,8 +2,8 @@ package com.backend.immilog.user.application;
 
 import com.backend.immilog.global.application.RedisDistributedLock;
 import com.backend.immilog.global.exception.CustomException;
-import com.backend.immilog.user.infrastructure.ReportRepository;
-import com.backend.immilog.user.infrastructure.UserRepository;
+import com.backend.immilog.user.model.interfaces.repositories.ReportRepository;
+import com.backend.immilog.user.model.interfaces.repositories.UserRepository;
 import com.backend.immilog.user.model.entities.Report;
 import com.backend.immilog.user.model.entities.User;
 import com.backend.immilog.user.presentation.request.UserReportRequest;
@@ -67,7 +67,7 @@ public class UserReportService {
                         targetUserSeq,
                         reporterUserSeq,
                         userReportRequest,
-                        userReportRequest.getReason().equals(OTHER)
+                        userReportRequest.reason().equals(OTHER)
                 )
         );
         log.info("User {} reported by {}", targetUserSeq, reporterUserSeq);

--- a/src/main/java/com/backend/immilog/user/application/UserSignInService.java
+++ b/src/main/java/com/backend/immilog/user/application/UserSignInService.java
@@ -5,7 +5,7 @@ import com.backend.immilog.global.exception.CustomException;
 import com.backend.immilog.global.model.TokenIssuanceDTO;
 import com.backend.immilog.global.security.JwtProvider;
 import com.backend.immilog.user.enums.UserStatus;
-import com.backend.immilog.user.infrastructure.UserRepository;
+import com.backend.immilog.user.model.interfaces.repositories.UserRepository;
 import com.backend.immilog.user.model.dtos.UserSignInDTO;
 import com.backend.immilog.user.model.embeddables.Location;
 import com.backend.immilog.user.model.entities.User;
@@ -37,7 +37,7 @@ public class UserSignInService {
             UserSignInRequest userSignInRequest,
             CompletableFuture<Pair<String, String>> country
     ) {
-        User user = getUserByEmail(userSignInRequest.getEmail());
+        User user = getUserByEmail(userSignInRequest.email());
         validateIfPasswordsMatches(userSignInRequest, user);
         validateIfUserStateIsActive(user);
         String accessToken = jwtProvider.issueAccessToken(TokenIssuanceDTO.of(user));
@@ -90,7 +90,7 @@ public class UserSignInService {
             UserSignInRequest userSignInRequest,
             User user
     ) {
-        if (!passwordEncoder.matches(userSignInRequest.getPassword(), user.getPassword())) {
+        if (!passwordEncoder.matches(userSignInRequest.password(), user.getPassword())) {
             throw new CustomException(PASSWORD_NOT_MATCH);
         }
     }

--- a/src/main/java/com/backend/immilog/user/application/UserSignUpService.java
+++ b/src/main/java/com/backend/immilog/user/application/UserSignUpService.java
@@ -2,7 +2,7 @@ package com.backend.immilog.user.application;
 
 import com.backend.immilog.global.exception.CustomException;
 import com.backend.immilog.user.enums.UserStatus;
-import com.backend.immilog.user.infrastructure.UserRepository;
+import com.backend.immilog.user.model.interfaces.repositories.UserRepository;
 import com.backend.immilog.user.model.entities.User;
 import com.backend.immilog.user.presentation.request.UserSignUpRequest;
 import lombok.RequiredArgsConstructor;
@@ -27,8 +27,8 @@ public class UserSignUpService {
     public Pair<Long, String> signUp(
             UserSignUpRequest userSignUpRequest
     ) {
-        validateUserNotExists(userSignUpRequest.getEmail());
-        String password = passwordEncoder.encode(userSignUpRequest.getPassword());
+        validateUserNotExists(userSignUpRequest.email());
+        String password = passwordEncoder.encode(userSignUpRequest.password());
         User user = userRepository.save(User.of(userSignUpRequest, password));
         return Pair.of(user.getSeq(), user.getNickName());
     }

--- a/src/main/java/com/backend/immilog/user/model/dtos/UserDTO.java
+++ b/src/main/java/com/backend/immilog/user/model/dtos/UserDTO.java
@@ -4,28 +4,25 @@ import com.backend.immilog.user.enums.Countries;
 import com.backend.immilog.user.enums.UserRole;
 import com.backend.immilog.user.enums.UserStatus;
 import com.backend.immilog.user.model.entities.User;
-import lombok.*;
+import lombok.Builder;
 
 import java.sql.Date;
 
-@Getter
-@AllArgsConstructor
-@NoArgsConstructor
 @Builder
-public class UserDTO {
-    private Long seq;
-    private String nickName;
-    private String email;
-    private String profileImage;
-    private Long reportedCount;
-    private Date reportedDate;
-    private Countries country;
-    private Countries interestCountry;
-    private String region;
-    private UserRole userRole;
-    private UserStatus userStatus;
-
-    public static UserDTO toDTO(
+public record UserDTO(
+        Long seq,
+        String nickName,
+        String email,
+        String profileImage,
+        Long reportedCount,
+        Date reportedDate,
+        Countries country,
+        Countries interestCountry,
+        String region,
+        UserRole userRole,
+        UserStatus userStatus
+) {
+    public static UserDTO from(
             User user
     ) {
         return UserDTO.builder()
@@ -43,7 +40,7 @@ public class UserDTO {
                 .build();
     }
 
-    public static UserDTO toDTO(
+    public static UserDTO from(
             Long seq,
             String nickName,
             String profileImage

--- a/src/main/java/com/backend/immilog/user/model/dtos/UserSignInDTO.java
+++ b/src/main/java/com/backend/immilog/user/model/dtos/UserSignInDTO.java
@@ -4,24 +4,20 @@ import com.backend.immilog.user.model.entities.User;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
 
-@Getter
-@AllArgsConstructor
-@NoArgsConstructor
 @Builder
-public class UserSignInDTO {
-    private Long userSeq;
-    private String email;
-    private String nickname;
-    private String accessToken;
-    private String refreshToken;
-    private String country;
-    private String interestCountry;
-    private String region;
-    private String userProfileUrl;
-    private Boolean isLocationMatch;
-
+public record UserSignInDTO(
+        Long userSeq,
+        String email,
+        String nickname,
+        String accessToken,
+        String refreshToken,
+        String country,
+        String interestCountry,
+        String region,
+        String userProfileUrl,
+        Boolean isLocationMatch
+) {
     public static UserSignInDTO of(
             User user,
             String accessToken,

--- a/src/main/java/com/backend/immilog/user/model/entities/Report.java
+++ b/src/main/java/com/backend/immilog/user/model/entities/Report.java
@@ -38,12 +38,12 @@ public class Report extends BaseDateEntity {
             boolean isOther
     ) {
         String description = isOther ?
-                reportUserRequest.getDescription() :
-                reportUserRequest.getReason().getReason();
+                reportUserRequest.description() :
+                reportUserRequest.reason().getReason();
         return Report.builder()
                 .reportedUserSeq(targetUserSeq)
                 .reporterUserSeq(reporterUserSeq)
-                .reason(reportUserRequest.getReason())
+                .reason(reportUserRequest.reason())
                 .description(description)
                 .build();
     }

--- a/src/main/java/com/backend/immilog/user/model/entities/User.java
+++ b/src/main/java/com/backend/immilog/user/model/entities/User.java
@@ -57,24 +57,24 @@ public class User extends BaseDateEntity {
             String encodedPassword
     ) {
         Countries interestCountry =
-                userSignUpRequest.getInterestCountry() != null ?
-                        Countries.getCountry(userSignUpRequest.getInterestCountry()) : null;
-        Countries country = Countries.getCountryByKoreanName(userSignUpRequest.getCountry());
+                userSignUpRequest.interestCountry() != null ?
+                        Countries.getCountry(userSignUpRequest.interestCountry()) : null;
+        Countries country = Countries.getCountryByKoreanName(userSignUpRequest.country());
 
         return User.builder()
-                .nickName(userSignUpRequest.getNickName())
-                .email(userSignUpRequest.getEmail())
+                .nickName(userSignUpRequest.nickName())
+                .email(userSignUpRequest.email())
                 .password(encodedPassword)
                 .location(
                         Location.of(
                                 country,
-                                userSignUpRequest.getRegion()
+                                userSignUpRequest.region()
                         )
                 )
                 .interestCountry(interestCountry)
                 .userRole(UserRole.ROLE_USER)
                 .userStatus(UserStatus.PENDING)
-                .imageUrl(userSignUpRequest.getProfileImage())
+                .imageUrl(userSignUpRequest.profileImage())
                 .build();
     }
 }

--- a/src/main/java/com/backend/immilog/user/model/interfaces/repositories/ReportRepository.java
+++ b/src/main/java/com/backend/immilog/user/model/interfaces/repositories/ReportRepository.java
@@ -1,4 +1,4 @@
-package com.backend.immilog.user.infrastructure;
+package com.backend.immilog.user.model.interfaces.repositories;
 
 import com.backend.immilog.user.model.entities.Report;
 import org.springframework.data.jpa.repository.JpaRepository;

--- a/src/main/java/com/backend/immilog/user/model/interfaces/repositories/UserRepository.java
+++ b/src/main/java/com/backend/immilog/user/model/interfaces/repositories/UserRepository.java
@@ -1,4 +1,4 @@
-package com.backend.immilog.user.infrastructure;
+package com.backend.immilog.user.model.interfaces.repositories;
 
 import com.backend.immilog.user.model.entities.User;
 import org.springframework.data.jpa.repository.JpaRepository;

--- a/src/main/java/com/backend/immilog/user/presentation/controller/AuthController.java
+++ b/src/main/java/com/backend/immilog/user/presentation/controller/AuthController.java
@@ -46,7 +46,7 @@ public class AuthController {
 
         return ResponseEntity
                 .status(OK)
-                .body(new ApiResponse(userSignInDTO));
+                .body(ApiResponse.of(userSignInDTO));
     }
 
 }

--- a/src/main/java/com/backend/immilog/user/presentation/controller/LocationController.java
+++ b/src/main/java/com/backend/immilog/user/presentation/controller/LocationController.java
@@ -37,7 +37,7 @@ public class LocationController {
 
         return ResponseEntity
                 .status(OK)
-                .body(new ApiResponse(
+                .body(ApiResponse.of(
                                 LocationResponse.from(
                                         Countries.getCountryByKoreanName(country.getFirst()),
                                         country.getSecond()

--- a/src/main/java/com/backend/immilog/user/presentation/controller/UserController.java
+++ b/src/main/java/com/backend/immilog/user/presentation/controller/UserController.java
@@ -43,7 +43,7 @@ public class UserController {
             @Valid @RequestBody UserSignUpRequest request
     ) {
         final Pair<Long, String> userSeqAndName = userSignUpService.signUp(request);
-        final String email = request.getEmail();
+        final String email = request.email();
         final String userName = userSeqAndName.getSecond();
         final Long userSeq = userSeqAndName.getFirst();
         final String url = String.format(API_LINK, userSeq);
@@ -71,11 +71,11 @@ public class UserController {
     ) {
         CompletableFuture<Pair<String, String>> country =
                 locationService.getCountry(
-                        request.getLatitude(),
-                        request.getLongitude()
+                        request.latitude(),
+                        request.longitude()
                 );
         final UserSignInDTO userSignInDto = userSignInService.signIn(request, country);
-        return ResponseEntity.status(OK).body(new ApiResponse(userSignInDto));
+        return ResponseEntity.status(OK).body(ApiResponse.of(userSignInDto));
     }
 
     @PatchMapping("/information")
@@ -87,13 +87,13 @@ public class UserController {
         final Long userSeq = jwtProvider.getIdFromToken(token);
         CompletableFuture<Pair<String, String>> country =
                 locationService.getCountry(
-                        userInfoUpdateRequest.getLatitude(),
-                        userInfoUpdateRequest.getLongitude()
+                        userInfoUpdateRequest.latitude(),
+                        userInfoUpdateRequest.longitude()
                 );
         userInformationService.updateInformation(
                 userSeq, country, userInfoUpdateRequest
         );
-        return ResponseEntity.status(OK).body(new ApiResponse(OK.value()));
+        return ResponseEntity.status(OK).body(ApiResponse.of(OK.value()));
     }
 
     @PatchMapping("/password/change")
@@ -115,7 +115,7 @@ public class UserController {
             @RequestParam String nickname
     ) {
         Boolean isNickNameAvailable = userSignUpService.checkNickname(nickname);
-        return ResponseEntity.status(OK).body(new ApiResponse(isNickNameAvailable));
+        return ResponseEntity.status(OK).body(ApiResponse.of(isNickNameAvailable));
     }
 
     @PatchMapping("/{userSeq}/{status}")

--- a/src/main/java/com/backend/immilog/user/presentation/request/UserInfoUpdateRequest.java
+++ b/src/main/java/com/backend/immilog/user/presentation/request/UserInfoUpdateRequest.java
@@ -6,19 +6,16 @@ import io.swagger.annotations.ApiModel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
 
-@Getter
-@AllArgsConstructor
-@NoArgsConstructor
 @Builder
 @ApiModel(value = "UserInfoUpdateRequest", description = "사용자 정보 수정 요청 DTO")
-public class UserInfoUpdateRequest {
-    private String nickName;
-    private String profileImage;
-    private Countries country;
-    private Countries interestCountry;
-    private Double latitude;
-    private Double longitude;
-    private UserStatus status;
+public record UserInfoUpdateRequest(
+        String nickName,
+        String profileImage,
+        Countries country,
+        Countries interestCountry,
+        Double latitude,
+        Double longitude,
+        UserStatus status
+) {
 }

--- a/src/main/java/com/backend/immilog/user/presentation/request/UserPasswordChangeRequest.java
+++ b/src/main/java/com/backend/immilog/user/presentation/request/UserPasswordChangeRequest.java
@@ -1,25 +1,20 @@
 package com.backend.immilog.user.presentation.request;
 
 import io.swagger.annotations.ApiModel;
-import lombok.AllArgsConstructor;
 import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
 
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.Size;
 
-@Getter
-@AllArgsConstructor
-@NoArgsConstructor
 @Builder
 @ApiModel(value = "UserPasswordChangeRequest", description = "사용자 비밀번호 변경 요청 DTO")
-public class UserPasswordChangeRequest {
-    @NotBlank(message = "비밀번호를 입력해주세요.")
-    @Size(min = 8, max = 15, message = "비밀번호는 8자에서 15자여야 합니다.")
-    private String existingPassword;
+public record UserPasswordChangeRequest(
+        @NotBlank(message = "비밀번호를 입력해주세요.")
+        @Size(min = 8, max = 15, message = "비밀번호는 8자에서 15자여야 합니다.")
+        String existingPassword,
 
-    @NotBlank(message = "새로운 비밀번호를 입력해주세요.")
-    @Size(min = 8, max = 15, message = "비밀번호는 8자에서 15자여야 합니다.")
-    private String newPassword;
+        @NotBlank(message = "새로운 비밀번호를 입력해주세요.")
+        @Size(min = 8, max = 15, message = "비밀번호는 8자에서 15자여야 합니다.")
+        String newPassword
+) {
 }

--- a/src/main/java/com/backend/immilog/user/presentation/request/UserReportRequest.java
+++ b/src/main/java/com/backend/immilog/user/presentation/request/UserReportRequest.java
@@ -2,17 +2,12 @@ package com.backend.immilog.user.presentation.request;
 
 import com.backend.immilog.user.enums.ReportReason;
 import io.swagger.annotations.ApiModel;
-import lombok.AllArgsConstructor;
 import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
 
-@Getter
-@AllArgsConstructor
-@NoArgsConstructor
 @Builder
 @ApiModel(value = "UserReportRequest", description = "사용자 신고 요청 DTO")
-public class UserReportRequest {
-    private ReportReason reason;
-    private String description;
+public record UserReportRequest(
+        ReportReason reason,
+        String description
+) {
 }

--- a/src/main/java/com/backend/immilog/user/presentation/request/UserSignInRequest.java
+++ b/src/main/java/com/backend/immilog/user/presentation/request/UserSignInRequest.java
@@ -1,29 +1,25 @@
 package com.backend.immilog.user.presentation.request;
 
 import io.swagger.annotations.ApiModel;
-import lombok.AllArgsConstructor;
 import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
 
 import javax.validation.constraints.Email;
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.Size;
 
-@Getter
-@AllArgsConstructor
-@NoArgsConstructor
 @Builder
 @ApiModel(value = "UserSignInRequest", description = "사용자 로그인 요청 DTO")
-public class UserSignInRequest {
-    @NotBlank(message = "이메일을 입력해주세요.")
-    @Email(message = "이메일 형식에 맞게 입력해주세요.")
-    private String email;
+public record UserSignInRequest(
+        @NotBlank(message = "이메일을 입력해주세요.")
+        @Email(message = "이메일 형식에 맞게 입력해주세요.")
+        String email,
 
-    @Size(min = 8, max = 15, message = "비밀번호는 8자에서 15자여야 합니다.")
-    @NotBlank(message = "비밀번호를 입력해주세요.")
-    private String password;
+        @Size(min = 8, max = 15, message = "비밀번호는 8자에서 15자여야 합니다.")
+        @NotBlank(message = "비밀번호를 입력해주세요.")
+        String password,
 
-    private Double latitude;
-    private Double longitude;
+        Double latitude,
+
+        Double longitude
+) {
 }

--- a/src/main/java/com/backend/immilog/user/presentation/request/UserSignUpRequest.java
+++ b/src/main/java/com/backend/immilog/user/presentation/request/UserSignUpRequest.java
@@ -1,39 +1,34 @@
 package com.backend.immilog.user.presentation.request;
 
 import io.swagger.annotations.ApiModel;
-import lombok.AllArgsConstructor;
 import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
 
 import javax.validation.constraints.Email;
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Size;
 
-@Getter
-@AllArgsConstructor
-@NoArgsConstructor
 @Builder
 @ApiModel(value = "UserSignUpRequest", description = "사용자 회원가입 요청 DTO")
-public class UserSignUpRequest {
-    @NotBlank(message = "닉네임을 입력해주세요.")
-    private String nickName;
+public record UserSignUpRequest(
+        @NotBlank(message = "닉네임을 입력해주세요.")
+        String nickName,
 
-    @Size(min = 8, max = 15, message = "비밀번호는 8자에서 15자여야 합니다.")
-    @NotBlank(message = "비밀번호를 입력해주세요.")
-    private String password;
+        @Size(min = 8, max = 15, message = "비밀번호는 8자에서 15자여야 합니다.")
+        @NotBlank(message = "비밀번호를 입력해주세요.")
+        String password,
 
-    @NotBlank(message = "이메일을 입력해주세요.")
-    @Email(message = "이메일 형식에 맞게 입력해주세요.")
-    private String email;
+        @NotBlank(message = "이메일을 입력해주세요.")
+        @Email(message = "이메일 형식에 맞게 입력해주세요.")
+        String email,
 
-    @NotNull(message = "국가를 입력해주세요.")
-    private String country;
+        @NotNull(message = "국가를 입력해주세요.")
+        String country,
 
-    private String interestCountry;
+        String interestCountry,
 
-    private String region;
+        String region,
 
-    private String profileImage;
+        String profileImage
+) {
 }

--- a/src/main/java/com/backend/immilog/user/presentation/response/LocationResponse.java
+++ b/src/main/java/com/backend/immilog/user/presentation/response/LocationResponse.java
@@ -4,16 +4,12 @@ import com.backend.immilog.user.enums.Countries;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
 
-@Getter
-@AllArgsConstructor
-@NoArgsConstructor
 @Builder
-public class LocationResponse {
-    private String country;
-    private String region;
-
+public record LocationResponse(
+        String country,
+        String region
+) {
     public static LocationResponse from(
             Countries country,
             String region

--- a/src/test/java/com/backend/immilog/global/presentation/controller/ImageControllerTest.java
+++ b/src/test/java/com/backend/immilog/global/presentation/controller/ImageControllerTest.java
@@ -48,7 +48,7 @@ class ImageControllerTest {
                 imageController.uploadImage(files, imagePath);
         // then
         assertThat(response.getStatusCode()).isEqualTo(OK);
-        ImageDTO data = (ImageDTO) Objects.requireNonNull(response.getBody()).getData();
+        ImageDTO data = (ImageDTO) Objects.requireNonNull(response.getBody()).data();
         assertThat(data.getImageUrl().get(0)).isEqualTo("imageUrl");
     }
 

--- a/src/test/java/com/backend/immilog/post/application/PostDeleteServiceTest.java
+++ b/src/test/java/com/backend/immilog/post/application/PostDeleteServiceTest.java
@@ -1,11 +1,12 @@
 package com.backend.immilog.post.application;
 
 import com.backend.immilog.global.exception.CustomException;
-import com.backend.immilog.post.infrastructure.PostRepository;
-import com.backend.immilog.post.infrastructure.PostResourceRepository;
 import com.backend.immilog.post.model.embeddables.PostMetaData;
 import com.backend.immilog.post.model.embeddables.PostUserData;
 import com.backend.immilog.post.model.entities.Post;
+import com.backend.immilog.post.model.services.PostDeleteService;
+import com.backend.immilog.post.model.repositories.PostRepository;
+import com.backend.immilog.post.model.repositories.PostResourceRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -32,7 +33,10 @@ class PostDeleteServiceTest {
     @BeforeEach
     void setUp() {
         MockitoAnnotations.openMocks(this);
-        postDeleteService = new PostDeleteService(postRepository, postResourceRepository);
+        postDeleteService = new PostDeleteServiceImpl(
+                postRepository,
+                postResourceRepository
+        );
     }
 
     @Test

--- a/src/test/java/com/backend/immilog/post/application/PostInquiryServiceTest.java
+++ b/src/test/java/com/backend/immilog/post/application/PostInquiryServiceTest.java
@@ -2,7 +2,8 @@ package com.backend.immilog.post.application;
 
 import com.backend.immilog.post.enums.Categories;
 import com.backend.immilog.post.enums.SortingMethods;
-import com.backend.immilog.post.infrastructure.PostRepository;
+import com.backend.immilog.post.model.services.PostInquiryService;
+import com.backend.immilog.post.model.repositories.PostRepository;
 import com.backend.immilog.post.model.dtos.PostDTO;
 import com.backend.immilog.user.enums.Countries;
 import org.assertj.core.api.Assertions;
@@ -31,7 +32,7 @@ class PostInquiryServiceTest {
     @BeforeEach
     void setUp() {
         MockitoAnnotations.openMocks(this);
-        postInquiryService = new PostInquiryService(postRepository);
+        postInquiryService = new PostInquiryServiceImpl(postRepository);
     }
 
     @Test

--- a/src/test/java/com/backend/immilog/post/application/PostInquiryServiceTest.java
+++ b/src/test/java/com/backend/immilog/post/application/PostInquiryServiceTest.java
@@ -65,4 +65,17 @@ class PostInquiryServiceTest {
         // then
         Assertions.assertThat(result.getTotalPages()).isEqualTo(1);
     }
+
+    @Test
+    @DisplayName("게시물 조회(단일 게시물)")
+    void getPost() {
+        // given
+        Long postSeq = 1L;
+        PostDTO postDTO = mock(PostDTO.class);
+        when(postRepository.getPost(postSeq)).thenReturn(java.util.Optional.of(postDTO));
+        // when
+        PostDTO result = postInquiryService.getPost(postSeq);
+        // then
+        Assertions.assertThat(result).isEqualTo(postDTO);
+    }
 }

--- a/src/test/java/com/backend/immilog/post/application/PostUpdateServiceTest.java
+++ b/src/test/java/com/backend/immilog/post/application/PostUpdateServiceTest.java
@@ -4,14 +4,15 @@ import com.backend.immilog.global.application.RedisDistributedLock;
 import com.backend.immilog.global.exception.CustomException;
 import com.backend.immilog.global.infrastructure.BulkInsertRepository;
 import com.backend.immilog.post.enums.ResourceType;
-import com.backend.immilog.post.infrastructure.InteractionUserRepository;
-import com.backend.immilog.post.infrastructure.PostRepository;
-import com.backend.immilog.post.infrastructure.PostResourceRepository;
 import com.backend.immilog.post.model.embeddables.PostMetaData;
 import com.backend.immilog.post.model.embeddables.PostUserData;
 import com.backend.immilog.post.model.entities.InteractionUser;
 import com.backend.immilog.post.model.entities.Post;
 import com.backend.immilog.post.model.entities.PostResource;
+import com.backend.immilog.post.model.repositories.InteractionUserRepository;
+import com.backend.immilog.post.model.services.PostUpdateService;
+import com.backend.immilog.post.model.repositories.PostRepository;
+import com.backend.immilog.post.model.repositories.PostResourceRepository;
 import com.backend.immilog.post.presentation.request.PostUpdateRequest;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
@@ -59,7 +60,7 @@ class PostUpdateServiceTest {
     @BeforeEach
     void setUp() throws SQLException {
         MockitoAnnotations.openMocks(this);
-        postUpdateService = new PostUpdateService(
+        postUpdateService = new PostUpdateServiceImpl(
                 postRepository,
                 postResourceRepository,
                 bulkInsertRepository,

--- a/src/test/java/com/backend/immilog/post/application/PostUploadServiceTest.java
+++ b/src/test/java/com/backend/immilog/post/application/PostUploadServiceTest.java
@@ -3,14 +3,15 @@ package com.backend.immilog.post.application;
 import com.backend.immilog.global.exception.CustomException;
 import com.backend.immilog.global.infrastructure.BulkInsertRepository;
 import com.backend.immilog.post.enums.Categories;
-import com.backend.immilog.post.infrastructure.PostRepository;
 import com.backend.immilog.post.model.entities.Post;
 import com.backend.immilog.post.model.entities.PostResource;
+import com.backend.immilog.post.model.services.PostUploadService;
+import com.backend.immilog.post.model.repositories.PostRepository;
 import com.backend.immilog.post.presentation.request.PostUploadRequest;
 import com.backend.immilog.user.enums.Countries;
-import com.backend.immilog.user.infrastructure.UserRepository;
 import com.backend.immilog.user.model.embeddables.Location;
 import com.backend.immilog.user.model.entities.User;
+import com.backend.immilog.user.model.interfaces.repositories.UserRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -52,7 +53,7 @@ class PostUploadServiceTest {
     @BeforeEach
     void setUp() throws SQLException {
         MockitoAnnotations.openMocks(this);
-        postUploadService = new PostUploadService(
+        postUploadService = new PostUploadServiceImpl(
                 postRepository,
                 userRepository,
                 bulkInsertRepository

--- a/src/test/java/com/backend/immilog/post/presentation/controller/PostControllerTest.java
+++ b/src/test/java/com/backend/immilog/post/presentation/controller/PostControllerTest.java
@@ -205,4 +205,22 @@ class PostControllerTest {
                 .isEqualTo(1);
 
     }
+
+    @Test
+    @DisplayName("게시물 상세 조회")
+    void getPost() {
+        // given
+        Long postSeq = 1L;
+        PostDTO postDTO = mock(PostDTO.class);
+        when(postInquiryService.getPost(postSeq)).thenReturn(postDTO);
+        when(postDTO.getSeq()).thenReturn(postSeq);
+
+        // when
+        ResponseEntity<ApiResponse> response = postController.getPost(postSeq);
+
+        // then
+        assertThat(response.getStatusCode()).isEqualTo(OK);
+        assertThat(Objects.requireNonNull(response.getBody()).data()).isEqualTo(postDTO);
+        assertThat(((PostDTO)(response.getBody()).data()).getSeq()).isEqualTo(postSeq);
+    }
 }

--- a/src/test/java/com/backend/immilog/post/presentation/controller/PostControllerTest.java
+++ b/src/test/java/com/backend/immilog/post/presentation/controller/PostControllerTest.java
@@ -2,13 +2,13 @@ package com.backend.immilog.post.presentation.controller;
 
 import com.backend.immilog.global.presentation.response.ApiResponse;
 import com.backend.immilog.global.security.JwtProvider;
-import com.backend.immilog.post.application.PostDeleteService;
-import com.backend.immilog.post.application.PostInquiryService;
-import com.backend.immilog.post.application.PostUpdateService;
-import com.backend.immilog.post.application.PostUploadService;
 import com.backend.immilog.post.enums.Categories;
 import com.backend.immilog.post.enums.SortingMethods;
 import com.backend.immilog.post.model.dtos.PostDTO;
+import com.backend.immilog.post.model.services.PostDeleteService;
+import com.backend.immilog.post.model.services.PostInquiryService;
+import com.backend.immilog.post.model.services.PostUpdateService;
+import com.backend.immilog.post.model.services.PostUploadService;
 import com.backend.immilog.post.presentation.request.PostUpdateRequest;
 import com.backend.immilog.post.presentation.request.PostUploadRequest;
 import com.backend.immilog.user.enums.Countries;
@@ -18,7 +18,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
-import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
@@ -29,8 +28,6 @@ import java.util.Objects;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.*;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 import static org.springframework.http.HttpStatus.*;
 
 @DisplayName("PostController 테스트")
@@ -204,7 +201,7 @@ class PostControllerTest {
 
         // then
         assertThat(response.getStatusCode()).isEqualTo(OK);
-        assertThat(((Page<PostDTO>) Objects.requireNonNull(response.getBody()).getData()).getTotalPages())
+        assertThat(((Page<PostDTO>) Objects.requireNonNull(response.getBody()).data()).getTotalPages())
                 .isEqualTo(1);
 
     }

--- a/src/test/java/com/backend/immilog/user/application/UserDetailsServiceImplTest.java
+++ b/src/test/java/com/backend/immilog/user/application/UserDetailsServiceImplTest.java
@@ -1,6 +1,6 @@
 package com.backend.immilog.user.application;
 
-import com.backend.immilog.user.infrastructure.UserRepository;
+import com.backend.immilog.user.model.interfaces.repositories.UserRepository;
 import com.backend.immilog.user.model.entities.User;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;

--- a/src/test/java/com/backend/immilog/user/application/UserInformationServiceTest.java
+++ b/src/test/java/com/backend/immilog/user/application/UserInformationServiceTest.java
@@ -5,7 +5,7 @@ import com.backend.immilog.global.application.RedisService;
 import com.backend.immilog.global.exception.CustomException;
 import com.backend.immilog.global.security.JwtProvider;
 import com.backend.immilog.user.enums.UserStatus;
-import com.backend.immilog.user.infrastructure.UserRepository;
+import com.backend.immilog.user.model.interfaces.repositories.UserRepository;
 import com.backend.immilog.user.model.dtos.UserSignInDTO;
 import com.backend.immilog.user.model.embeddables.Location;
 import com.backend.immilog.user.model.entities.User;
@@ -86,7 +86,7 @@ class UserInformationServiceTest {
         verify(redisService, times(1)).saveKeyAndValue(
                 "Refresh: refreshToken", user.getEmail(), 5 * 29 * 24 * 60
         );
-        assertThat(result.getUserSeq()).isEqualTo(userSeq);
+        assertThat(result.userSeq()).isEqualTo(userSeq);
     }
 
     @Test
@@ -117,7 +117,7 @@ class UserInformationServiceTest {
         verify(redisService, times(1)).saveKeyAndValue(
                 "Refresh: refreshToken", user.getEmail(), 5 * 29 * 24 * 60
         );
-        assertThat(result.getUserSeq()).isEqualTo(userSeq);
+        assertThat(result.userSeq()).isEqualTo(userSeq);
     }
 
     @Test

--- a/src/test/java/com/backend/immilog/user/application/UserReportServiceTest.java
+++ b/src/test/java/com/backend/immilog/user/application/UserReportServiceTest.java
@@ -4,8 +4,8 @@ import com.backend.immilog.global.application.RedisDistributedLock;
 import com.backend.immilog.global.exception.CustomException;
 import com.backend.immilog.user.enums.ReportReason;
 import com.backend.immilog.user.enums.UserStatus;
-import com.backend.immilog.user.infrastructure.ReportRepository;
-import com.backend.immilog.user.infrastructure.UserRepository;
+import com.backend.immilog.user.model.interfaces.repositories.ReportRepository;
+import com.backend.immilog.user.model.interfaces.repositories.UserRepository;
 import com.backend.immilog.user.model.embeddables.Location;
 import com.backend.immilog.user.model.embeddables.ReportInfo;
 import com.backend.immilog.user.model.entities.Report;
@@ -99,7 +99,7 @@ class UserReportServiceTest {
         // given
         Long targetUserSeq = 1L;
         Long reporterUserSeq = 1L;
-        UserReportRequest reportUserRequest = new UserReportRequest();
+        UserReportRequest reportUserRequest = UserReportRequest.builder().build();
         when(reportRepository.existsByReportedUserSeqAndReporterUserSeq(
                 targetUserSeq, reporterUserSeq
         )).thenReturn(false);
@@ -119,7 +119,7 @@ class UserReportServiceTest {
         // given
         Long targetUserSeq = 1L;
         Long reporterUserSeq = 2L;
-        UserReportRequest reportUserRequest = new UserReportRequest();
+        UserReportRequest reportUserRequest = UserReportRequest.builder().build();
         when(reportRepository.existsByReportedUserSeqAndReporterUserSeq(
                 targetUserSeq, reporterUserSeq
         )).thenReturn(true);

--- a/src/test/java/com/backend/immilog/user/application/UserSignInServiceTest.java
+++ b/src/test/java/com/backend/immilog/user/application/UserSignInServiceTest.java
@@ -7,7 +7,7 @@ import com.backend.immilog.global.security.JwtProvider;
 import com.backend.immilog.user.enums.Countries;
 import com.backend.immilog.user.enums.UserRole;
 import com.backend.immilog.user.enums.UserStatus;
-import com.backend.immilog.user.infrastructure.UserRepository;
+import com.backend.immilog.user.model.interfaces.repositories.UserRepository;
 import com.backend.immilog.user.model.dtos.UserSignInDTO;
 import com.backend.immilog.user.model.embeddables.Location;
 import com.backend.immilog.user.model.entities.User;
@@ -69,16 +69,16 @@ class UserSignInServiceTest {
 
         User user = User.builder()
                 .seq(1L)
-                .email(userSignInRequest.getEmail())
+                .email(userSignInRequest.email())
                 .userStatus(UserStatus.ACTIVE)
                 .userRole(UserRole.ROLE_USER)
-                .password(passwordEncoder.encode(userSignInRequest.getPassword()))
+                .password(passwordEncoder.encode(userSignInRequest.password()))
                 .location(location)
                 .build();
 
-        when(userRepository.findByEmail(userSignInRequest.getEmail()))
+        when(userRepository.findByEmail(userSignInRequest.email()))
                 .thenReturn(Optional.of(user));
-        when(passwordEncoder.matches(userSignInRequest.getPassword(), user.getPassword()))
+        when(passwordEncoder.matches(userSignInRequest.password(), user.getPassword()))
                 .thenReturn(true);
         when(jwtProvider.issueAccessToken(any(TokenIssuanceDTO.class)))
                 .thenReturn("accessToken");
@@ -91,8 +91,8 @@ class UserSignInServiceTest {
         UserSignInDTO userSignInDTO = userSignInService.signIn(userSignInRequest, country);
 
         // then
-        assertThat(userSignInDTO.getUserSeq()).isEqualTo(user.getSeq());
-        assertThat(userSignInDTO.getAccessToken()).isEqualTo("accessToken");
+        assertThat(userSignInDTO.userSeq()).isEqualTo(user.getSeq());
+        assertThat(userSignInDTO.accessToken()).isEqualTo("accessToken");
         verify(jwtProvider, times(1)).issueAccessToken(any(TokenIssuanceDTO.class));
         verify(jwtProvider, times(1)).issueRefreshToken();
     }
@@ -115,10 +115,10 @@ class UserSignInServiceTest {
 
         User user = User.builder()
                 .seq(1L)
-                .email(userSignInRequest.getEmail())
+                .email(userSignInRequest.email())
                 .userStatus(UserStatus.ACTIVE)
                 .userRole(UserRole.ROLE_USER)
-                .password(passwordEncoder.encode(userSignInRequest.getPassword()))
+                .password(passwordEncoder.encode(userSignInRequest.password()))
                 .location(location)
                 .build();
 

--- a/src/test/java/com/backend/immilog/user/application/UserSignUpServiceTest.java
+++ b/src/test/java/com/backend/immilog/user/application/UserSignUpServiceTest.java
@@ -1,8 +1,7 @@
 package com.backend.immilog.user.application;
 
 import com.backend.immilog.global.exception.CustomException;
-import com.backend.immilog.user.enums.UserStatus;
-import com.backend.immilog.user.infrastructure.UserRepository;
+import com.backend.immilog.user.model.interfaces.repositories.UserRepository;
 import com.backend.immilog.user.model.entities.User;
 import com.backend.immilog.user.presentation.request.UserSignUpRequest;
 import org.junit.jupiter.api.BeforeEach;

--- a/src/test/java/com/backend/immilog/user/presentation/controller/AuthControllerTest.java
+++ b/src/test/java/com/backend/immilog/user/presentation/controller/AuthControllerTest.java
@@ -75,7 +75,7 @@ class AuthControllerTest {
 
         // then
         assertThat(response.getStatusCode()).isEqualTo(OK);
-        Object data = Objects.requireNonNull(response.getBody()).getData();
-        assertThat(((UserSignInDTO) data).getEmail()).isEqualTo(userSignInDTO.getEmail());
+        Object data = Objects.requireNonNull(response.getBody()).data();
+        assertThat(((UserSignInDTO) data).email()).isEqualTo(userSignInDTO.email());
     }
 }

--- a/src/test/java/com/backend/immilog/user/presentation/controller/LocationControllerTest.java
+++ b/src/test/java/com/backend/immilog/user/presentation/controller/LocationControllerTest.java
@@ -52,10 +52,10 @@ class LocationControllerTest {
         // then
         assertThat(response).isNotNull();
         assertThat(OK).isEqualTo(response.getStatusCode());
-        LocationResponse locationResponse = (LocationResponse) response.getBody().getData();
+        LocationResponse locationResponse = (LocationResponse) response.getBody().data();
         assertThat(locationResponse).isNotNull();
         assertThat(Countries.getCountryByKoreanName(country).getCountryName())
-                .isEqualTo(locationResponse.getCountry());
-        assertThat(SOUTH_KOREA.toString()).isEqualTo(locationResponse.getCountry());
+                .isEqualTo(locationResponse.country());
+        assertThat(SOUTH_KOREA.toString()).isEqualTo(locationResponse.country());
     }
 }

--- a/src/test/java/com/backend/immilog/user/presentation/controller/UserControllerTest.java
+++ b/src/test/java/com/backend/immilog/user/presentation/controller/UserControllerTest.java
@@ -84,7 +84,7 @@ class UserControllerTest {
 
         // then
         verify(emailService, times(1)).sendHtmlEmail(
-                param.getEmail(),
+                param.email(),
                 EmailComponents.EMAIL_SIGN_UP_SUBJECT,
                 String.format(
                         EmailComponents.HTML_SIGN_UP_CONTENT,
@@ -128,9 +128,9 @@ class UserControllerTest {
                 .build();
 
 
-        when(locationService.getCountry(param.getLatitude(), param.getLongitude()))
+        when(locationService.getCountry(param.latitude(), param.longitude()))
                 .thenReturn(CompletableFuture.completedFuture(Pair.of("대한민국", "서울")));
-        when(userSignInService.signIn(param, locationService.getCountry(param.getLatitude(), param.getLongitude())))
+        when(userSignInService.signIn(param, locationService.getCountry(param.latitude(), param.longitude())))
                 .thenReturn(UserSignInDTO.builder().build());
         // when
         ResponseEntity<ApiResponse> response = userController.signIn(param);
@@ -156,7 +156,7 @@ class UserControllerTest {
                         .build();
 
         when(jwtProvider.getIdFromToken(token)).thenReturn(1L);
-        when(locationService.getCountry(param.getLatitude(), param.getLongitude()))
+        when(locationService.getCountry(param.latitude(), param.longitude()))
                 .thenReturn(CompletableFuture.completedFuture(Pair.of("Japan", "Tokyo")));
         // when
         ResponseEntity<ApiResponse> response =
@@ -166,7 +166,7 @@ class UserControllerTest {
         assertThat(response.getStatusCode()).isEqualTo(OK);
         verify(userInformationService, times(1)).updateInformation(
                 1L,
-                locationService.getCountry(param.getLatitude(), param.getLongitude()),
+                locationService.getCountry(param.latitude(), param.longitude()),
                 param
         );
     }
@@ -205,7 +205,7 @@ class UserControllerTest {
 
         // then
         ApiResponse body = Objects.requireNonNull(response.getBody());
-        assertThat(body.getData()).isEqualTo(true);
+        assertThat(body.data()).isEqualTo(true);
     }
 
     @Test


### PR DESCRIPTION
* refactor (global) : DTO 클래스를 Java 레코드로 변경하여 불변성과 간결성 향상

* refactor (post) : DTO 클래스를 Java 레코드로 변경하여 불변성과 간결성 향상

* refactor (user) : DTO 클래스를 Java 레코드로 변경하여 불변성과 간결성 향상

* refactor (global) : record DTO 에 맞춰 get 메서드 수정

* refactor (post) : record DTO 에 맞춰 get 메서드 수정

* refactor (user) : record DTO 에 맞춰 get 메서드 수정

* refactor (global) : record DTO 에 맞춰 get 메서드 수정

* test (post) : record DTO 에 맞춰 get 메서드 수정

* refactor (post) : 서비스 인터페이스와 구현체를 분리하여 도메인 결합도 감소 및 유연성 향상

* refactor (user) : 서비스 인터페이스와 구현체를 분리하여 도메인 결합도 감소 및 유연성 향상

* test (user) : 서비스 인터페이스와 구현체를 분리하여 도메인 결합도 감소 및 유연성 향상

* test (post) : 서비스 인터페이스와 구현체를 분리하여 도메인 결합도 감소 및 유연성 향상

### 작업 내용
- 프로젝트 전체의 서비스 인터페이스와 구현체를 분리하여 도메인 결합도 감소 및 유연성 향상
- 레포지토리의 인터페이스 를 모델 하위로 둠으로써 도메인 결합도 감소
- 테스트 코드 수정

### 특이 사항
- 없음
