### PR TITLE
feat (post) : 게시물 댓글 및 대댓글 작성 기능 추가 (#234)

### DIFF
--- a/src/main/java/com/backend/immilog/global/exception/ErrorCode.java
+++ b/src/main/java/com/backend/immilog/global/exception/ErrorCode.java
@@ -46,7 +46,9 @@ public enum ErrorCode {
     JOB_BOARD_NOT_FOUND(NOT_FOUND, "존재하지 않는 구인 게시판입니다."),
     COMPANY_NOT_FOUND(NOT_FOUND, "존재하지 않는 회사입니다."),
 
-    FAILED_TO_SAVE_POST(BAD_REQUEST, "게시물을 저장하는데 실패하였습니다.");
+    FAILED_TO_SAVE_POST(BAD_REQUEST, "게시물을 저장하는데 실패하였습니다."),
+
+    INVALID_REFERENCE_TYPE(BAD_REQUEST, "유효하지 않은 참조 타입입니다.");
 
     private final HttpStatus status;
     private final String message;

--- a/src/main/java/com/backend/immilog/post/application/CommentUploadServiceImpl.java
+++ b/src/main/java/com/backend/immilog/post/application/CommentUploadServiceImpl.java
@@ -1,0 +1,53 @@
+package com.backend.immilog.post.application;
+
+import com.backend.immilog.global.exception.CustomException;
+import com.backend.immilog.post.enums.ReferenceType;
+import com.backend.immilog.post.model.entities.Comment;
+import com.backend.immilog.post.model.entities.Post;
+import com.backend.immilog.post.model.repositories.CommentRepository;
+import com.backend.immilog.post.model.repositories.PostRepository;
+import com.backend.immilog.post.model.services.CommentUploadService;
+import com.backend.immilog.post.presentation.request.CommentUploadRequest;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import static com.backend.immilog.global.exception.ErrorCode.POST_NOT_FOUND;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class CommentUploadServiceImpl implements CommentUploadService {
+    private final CommentRepository commentRepository;
+    private final PostRepository postRepository;
+
+    @Override
+    public void uploadComment(
+            Long userId,
+            Long postSeq,
+            String referenceType,
+            CommentUploadRequest commentUploadRequest
+    ) {
+        Post post = getPost(postSeq);
+        post.setCommentCount(post.getCommentCount() + 1);
+
+        ReferenceType reference = ReferenceType.getByString(referenceType);
+
+        Comment comment = Comment.of(
+                userId,
+                postSeq,
+                commentUploadRequest.content(),
+                reference
+        );
+
+        commentRepository.save(comment);
+    }
+
+    private Post getPost(
+            Long postSeq
+    ) {
+        return postRepository
+                .findById(postSeq)
+                .orElseThrow(() -> new CustomException(POST_NOT_FOUND));
+    }
+}

--- a/src/main/java/com/backend/immilog/post/application/PostInquiryServiceImpl.java
+++ b/src/main/java/com/backend/immilog/post/application/PostInquiryServiceImpl.java
@@ -3,6 +3,8 @@ package com.backend.immilog.post.application;
 import com.backend.immilog.global.exception.CustomException;
 import com.backend.immilog.post.enums.Categories;
 import com.backend.immilog.post.enums.SortingMethods;
+import com.backend.immilog.post.model.dtos.CommentDTO;
+import com.backend.immilog.post.model.repositories.CommentRepository;
 import com.backend.immilog.post.model.services.PostInquiryService;
 import com.backend.immilog.post.model.repositories.PostRepository;
 import com.backend.immilog.post.model.dtos.PostDTO;
@@ -14,6 +16,8 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
+import java.util.List;
+
 import static com.backend.immilog.global.exception.ErrorCode.POST_NOT_FOUND;
 
 @Slf4j
@@ -21,6 +25,7 @@ import static com.backend.immilog.global.exception.ErrorCode.POST_NOT_FOUND;
 @RequiredArgsConstructor
 public class PostInquiryServiceImpl implements PostInquiryService {
     private final PostRepository postRepository;
+    private final CommentRepository commentRepository;
 
     @Override
     public Page<PostDTO> getPosts(
@@ -45,9 +50,10 @@ public class PostInquiryServiceImpl implements PostInquiryService {
     public PostDTO getPost(
             Long postSeq
     ) {
-        return postRepository
-                .getPost(postSeq)
-                .orElseThrow(()-> new CustomException(POST_NOT_FOUND));
+        PostDTO postDTO = getPostDTO(postSeq);
+        List<CommentDTO> comments = commentRepository.getComments(postSeq);
+        postDTO.setComments(comments);
+        return postDTO;
     }
 
     @Override
@@ -68,5 +74,11 @@ public class PostInquiryServiceImpl implements PostInquiryService {
         Pageable pageable = PageRequest.of(page, 10);
         return postRepository
                 .getPostsByUserSeq(userSeq, pageable);
+    }
+
+    private PostDTO getPostDTO(Long postSeq) {
+        return postRepository
+                .getPost(postSeq)
+                .orElseThrow(() -> new CustomException(POST_NOT_FOUND));
     }
 }

--- a/src/main/java/com/backend/immilog/post/enums/ReferenceType.java
+++ b/src/main/java/com/backend/immilog/post/enums/ReferenceType.java
@@ -1,0 +1,26 @@
+package com.backend.immilog.post.enums;
+
+import com.backend.immilog.global.exception.CustomException;
+import com.backend.immilog.global.exception.ErrorCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+import java.util.Arrays;
+
+@Getter
+@RequiredArgsConstructor
+public enum ReferenceType {
+    COMMENT("comments"),
+    POST("posts");
+
+    private final String stringValue;
+
+    public static ReferenceType getByString(
+            String referenceType
+    ) {
+        return Arrays.stream(values())
+                .filter(type -> type.stringValue.equals(referenceType))
+                .findFirst()
+                .orElseThrow(() -> new CustomException(ErrorCode.INVALID_REFERENCE_TYPE));
+    }
+}

--- a/src/main/java/com/backend/immilog/post/infrastructure/CommentRepositoryImpl.java
+++ b/src/main/java/com/backend/immilog/post/infrastructure/CommentRepositoryImpl.java
@@ -1,0 +1,62 @@
+package com.backend.immilog.post.infrastructure;
+
+import com.backend.immilog.post.model.dtos.CommentDTO;
+import com.backend.immilog.post.model.entities.QComment;
+import com.backend.immilog.post.model.repositories.CommentRepositoryCustom;
+import com.backend.immilog.user.model.entities.QUser;
+import com.querydsl.core.types.Projections;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+import static com.backend.immilog.post.enums.ReferenceType.COMMENT;
+import static com.backend.immilog.post.enums.ReferenceType.POST;
+import static com.querydsl.core.group.GroupBy.groupBy;
+import static com.querydsl.core.group.GroupBy.list;
+
+@Repository
+@RequiredArgsConstructor
+public class CommentRepositoryImpl implements CommentRepositoryCustom {
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public List<CommentDTO> getComments(Long postSeq) {
+        QComment comment = QComment.comment;
+        QComment childComment = new QComment("childComment");
+        QUser user = QUser.user;
+        QUser childCommentUser = new QUser("childCommentUser");
+
+        return queryFactory
+                .select(comment, user, list(childComment), list(childCommentUser))
+                .from(comment)
+                .leftJoin(user)
+                .on(comment.userSeq.eq(user.seq))
+                .leftJoin(childComment)
+                .on(childComment.postSeq.eq(postSeq)
+                        .and(childComment.parentSeq.eq(comment.seq))
+                        .and(childComment.referenceType.eq(COMMENT))
+                )
+                .leftJoin(childCommentUser)
+                .on(childComment.userSeq.eq(childCommentUser.seq))
+                .where(comment.postSeq.eq(postSeq)
+                        .and(comment.parentSeq.isNull())
+                        .and(comment.referenceType.eq(POST))
+                )
+                .orderBy(comment.createdAt.desc())
+                .transform(
+                        groupBy(comment.postSeq).list(
+                                Projections.constructor(
+                                        CommentDTO.class,
+                                        comment,
+                                        user,
+                                        Projections.list(childComment),
+                                        Projections.list(childCommentUser)
+                                )
+                        )
+                );
+    }
+}
+
+

--- a/src/main/java/com/backend/immilog/post/model/dtos/CommentDTO.java
+++ b/src/main/java/com/backend/immilog/post/model/dtos/CommentDTO.java
@@ -1,4 +1,90 @@
 package com.backend.immilog.post.model.dtos;
 
-public record CommentDTO() {
+import com.backend.immilog.post.enums.PostStatus;
+import com.backend.immilog.post.model.entities.Comment;
+import com.backend.immilog.user.model.dtos.UserDTO;
+import com.backend.immilog.user.model.entities.User;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class CommentDTO {
+    private Long seq;
+    private UserDTO user;
+    private String content;
+    private List<CommentDTO> replies;
+    private int upVotes;
+    private int downVotes;
+    private int replyCount;
+    private List<Long> likeUsers;
+    private PostStatus status;
+    private LocalDateTime createdAt;
+
+    public CommentDTO(
+            Comment comment,
+            User user,
+            List<Comment> replies,
+            List<User> replyUsers
+    ) {
+        List<CommentDTO> replyList = combineReplies(replies, replyUsers);
+
+        this.seq = comment.getSeq();
+        this.user = UserDTO.from(user);
+        this.content = comment.getContent();
+        this.replies = replyList;
+        this.upVotes = comment.getLikeCount();
+        this.replyCount = comment.getReplyCount();
+        this.likeUsers = comment.getLikeUsers();
+        this.status = comment.getStatus();
+        this.createdAt = comment.getCreatedAt();
+    }
+
+    public static CommentDTO of(
+            Comment comment,
+            User user
+    ) {
+        return CommentDTO.builder()
+                .seq(comment.getSeq())
+                .user(UserDTO.from(user))
+                .content(comment.getContent())
+                .replies(new ArrayList<>())
+                .upVotes(comment.getLikeCount())
+                .replyCount(comment.getReplyCount())
+                .likeUsers(comment.getLikeUsers())
+                .status(comment.getStatus())
+                .createdAt(comment.getCreatedAt())
+                .build();
+    }
+
+    private List<CommentDTO> combineReplies(
+            List<Comment> replies,
+            List<User> replyUsers
+    ) {
+        if (replies.isEmpty() || replyUsers.isEmpty()) {
+            return List.of();
+        }
+        return replies
+                .stream()
+                .map(reply -> {
+                    return replyUsers.stream()
+                            .filter(Objects::nonNull)
+                            .filter(u -> u.getSeq().equals(reply.getUserSeq()))
+                            .findFirst()
+                            .map(replyUser -> CommentDTO.of(reply, replyUser))
+                            .orElse(null);
+                })
+                .filter(Objects::nonNull)
+                .toList();
+    }
+
 }

--- a/src/main/java/com/backend/immilog/post/model/entities/Comment.java
+++ b/src/main/java/com/backend/immilog/post/model/entities/Comment.java
@@ -1,0 +1,73 @@
+package com.backend.immilog.post.model.entities;
+
+import com.backend.immilog.global.model.BaseDateEntity;
+import com.backend.immilog.post.enums.PostStatus;
+import com.backend.immilog.post.enums.ReferenceType;
+import com.backend.immilog.post.model.dtos.CommentDTO;
+import com.backend.immilog.user.model.dtos.UserDTO;
+import com.backend.immilog.user.model.entities.User;
+import lombok.*;
+import org.hibernate.annotations.Cascade;
+import org.hibernate.annotations.CascadeType;
+import org.hibernate.annotations.DynamicUpdate;
+
+import javax.persistence.*;
+import java.util.ArrayList;
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+@DynamicUpdate
+@Entity
+public class Comment extends BaseDateEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long seq;
+
+    private Long userSeq;
+
+    private Long postSeq;
+
+    private Long parentSeq;
+
+    @Setter
+    private int replyCount;
+
+    @Setter
+    private Integer likeCount;
+
+    private String content;
+
+    @Enumerated(EnumType.STRING)
+    private ReferenceType referenceType;
+
+    @Enumerated(EnumType.STRING)
+    private PostStatus status;
+
+    @ElementCollection(fetch = FetchType.LAZY)
+    @Cascade(value = CascadeType.ALL)
+    private List<Long> likeUsers = new ArrayList<>();
+
+    public static Comment of(
+            Long userSeq,
+            Long postSeq,
+            String content,
+            ReferenceType referenceType
+    ) {
+        return Comment.builder()
+                .userSeq(userSeq)
+                .postSeq(postSeq)
+                .content(content)
+                .likeCount(0)
+                .replyCount(0)
+                .status(PostStatus.NORMAL)
+                .referenceType(referenceType)
+                .likeUsers(new ArrayList<>())
+                .build();
+    }
+
+}
+

--- a/src/main/java/com/backend/immilog/post/model/repositories/CommentRepository.java
+++ b/src/main/java/com/backend/immilog/post/model/repositories/CommentRepository.java
@@ -1,0 +1,8 @@
+package com.backend.immilog.post.model.repositories;
+
+import com.backend.immilog.post.model.entities.Comment;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CommentRepository
+        extends JpaRepository<Comment, Long>, CommentRepositoryCustom {
+}

--- a/src/main/java/com/backend/immilog/post/model/repositories/CommentRepositoryCustom.java
+++ b/src/main/java/com/backend/immilog/post/model/repositories/CommentRepositoryCustom.java
@@ -1,0 +1,11 @@
+package com.backend.immilog.post.model.repositories;
+
+import com.backend.immilog.post.model.dtos.CommentDTO;
+
+import java.util.List;
+
+public interface CommentRepositoryCustom {
+    List<CommentDTO> getComments(
+            Long postSeq
+    );
+}

--- a/src/main/java/com/backend/immilog/post/model/services/CommentUploadService.java
+++ b/src/main/java/com/backend/immilog/post/model/services/CommentUploadService.java
@@ -1,0 +1,15 @@
+package com.backend.immilog.post.model.services;
+
+import com.backend.immilog.post.presentation.request.CommentUploadRequest;
+import org.springframework.transaction.annotation.Transactional;
+
+public interface CommentUploadService {
+
+    @Transactional
+    void uploadComment(
+            Long userId,
+            Long postSeq,
+            String referenceType,
+            CommentUploadRequest commentUploadRequest
+    );
+}

--- a/src/main/java/com/backend/immilog/post/presentation/controller/CommentController.java
+++ b/src/main/java/com/backend/immilog/post/presentation/controller/CommentController.java
@@ -1,0 +1,43 @@
+package com.backend.immilog.post.presentation.controller;
+
+import com.backend.immilog.global.presentation.response.ApiResponse;
+import com.backend.immilog.global.security.JwtProvider;
+import com.backend.immilog.post.model.services.CommentUploadService;
+import com.backend.immilog.post.presentation.request.CommentUploadRequest;
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import javax.validation.Valid;
+
+import static org.apache.http.HttpHeaders.AUTHORIZATION;
+import static org.springframework.http.HttpStatus.CREATED;
+
+@Api(tags = "Comment API", description = "댓글 관련 API")
+@RequestMapping("/api/v1/comments")
+@RequiredArgsConstructor
+@RestController
+public class CommentController {
+    private final CommentUploadService commentUploadService;
+    private final JwtProvider jwtProvider;
+
+    @PostMapping("/{referenceType}/{postSeq}")
+    @ApiOperation(value = "댓글 작성", notes = "댓글을 작성합니다.")
+    public ResponseEntity<ApiResponse> createComment(
+            @PathVariable String referenceType,
+            @PathVariable Long postSeq,
+            @RequestHeader(AUTHORIZATION) String token,
+            @Valid @RequestBody CommentUploadRequest commentUploadRequest
+    ) {
+        Long userId = jwtProvider.getIdFromToken(token);
+        commentUploadService.uploadComment(
+                userId,
+                postSeq,
+                referenceType,
+                commentUploadRequest
+        );
+        return ResponseEntity.status(CREATED).build();
+    }
+}

--- a/src/main/java/com/backend/immilog/post/presentation/request/CommentUploadRequest.java
+++ b/src/main/java/com/backend/immilog/post/presentation/request/CommentUploadRequest.java
@@ -1,0 +1,11 @@
+package com.backend.immilog.post.presentation.request;
+
+import io.swagger.annotations.ApiModel;
+
+import javax.validation.constraints.NotNull;
+
+@ApiModel(value = "CommentUploadRequest", description = "댓글 업로드 요청 DTO")
+public record CommentUploadRequest(
+        @NotNull(message = "댓글 내용을 입력해주세요.") String content
+) {
+}

--- a/src/test/java/com/backend/immilog/post/application/CommentUploadServiceImplTest.java
+++ b/src/test/java/com/backend/immilog/post/application/CommentUploadServiceImplTest.java
@@ -1,0 +1,105 @@
+package com.backend.immilog.post.application;
+
+import com.backend.immilog.global.exception.CustomException;
+import com.backend.immilog.post.model.entities.Post;
+import com.backend.immilog.post.model.repositories.CommentRepository;
+import com.backend.immilog.post.model.repositories.PostRepository;
+import com.backend.immilog.post.model.services.CommentUploadService;
+import com.backend.immilog.post.presentation.request.CommentUploadRequest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import java.util.Optional;
+
+import static com.backend.immilog.global.exception.ErrorCode.INVALID_REFERENCE_TYPE;
+import static com.backend.immilog.global.exception.ErrorCode.POST_NOT_FOUND;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
+import static org.mockito.Mockito.*;
+
+@DisplayName("CommentUploadService 테스트")
+class CommentUploadServiceImplTest {
+    @Mock
+    private CommentRepository commentRepository;
+    @Mock
+    private PostRepository postRepository;
+    private CommentUploadService commentUploadService;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+        commentUploadService = new CommentUploadServiceImpl(
+                commentRepository,
+                postRepository
+        );
+    }
+
+    @Test
+    @DisplayName("댓글 업로드 - 성공")
+    void uploadComment() {
+        // given
+        Long userId = 1L;
+        Long postSeq = 1L;
+        String referenceType = "posts";
+        CommentUploadRequest commentUploadRequest =
+                new CommentUploadRequest("content");
+        Post post = Post.builder().commentCount(0L).build();
+        when(postRepository.findById(postSeq)).thenReturn(Optional.of(post));
+        // when
+        commentUploadService.uploadComment(
+                userId,
+                postSeq,
+                referenceType,
+                commentUploadRequest
+        );
+        // then
+        verify(postRepository, times(1)).findById(postSeq);
+        verify(commentRepository, times(1)).save(any());
+    }
+
+    @Test
+    @DisplayName("댓글 업로드 - 실패:없는 게시물")
+    void uploadComment_fail() {
+        // given
+        Long userId = 1L;
+        Long postSeq = 1L;
+        String referenceType = "posts";
+        CommentUploadRequest commentUploadRequest =
+                new CommentUploadRequest("content");
+        when(postRepository.findById(postSeq)).thenReturn(Optional.empty());
+        // when & then
+        assertThatThrownBy(() -> commentUploadService.uploadComment(
+                userId,
+                postSeq,
+                referenceType,
+                commentUploadRequest
+        ))
+                .isInstanceOf(CustomException.class)
+                .hasMessage(POST_NOT_FOUND.getMessage());
+    }
+
+    @Test
+    @DisplayName("댓글 업로드 - 실패:없는 참조 타입")
+    void uploadComment_fail_invalid_ref_type() {
+        // given
+        Long userId = 1L;
+        Long postSeq = 1L;
+        String referenceType = "text";
+        CommentUploadRequest commentUploadRequest =
+                new CommentUploadRequest("content");
+        Post post = Post.builder().commentCount(0L).build();
+        when(postRepository.findById(postSeq)).thenReturn(Optional.of(post));
+        // when & then
+        assertThatThrownBy(() -> commentUploadService.uploadComment(
+                userId,
+                postSeq,
+                referenceType,
+                commentUploadRequest
+        ))
+                .isInstanceOf(CustomException.class)
+                .hasMessage(INVALID_REFERENCE_TYPE.getMessage());
+    }
+
+}

--- a/src/test/java/com/backend/immilog/post/application/PostInquiryServiceTest.java
+++ b/src/test/java/com/backend/immilog/post/application/PostInquiryServiceTest.java
@@ -3,6 +3,7 @@ package com.backend.immilog.post.application;
 import com.backend.immilog.post.enums.Categories;
 import com.backend.immilog.post.enums.SortingMethods;
 import com.backend.immilog.post.model.dtos.PostDTO;
+import com.backend.immilog.post.model.repositories.CommentRepository;
 import com.backend.immilog.post.model.repositories.PostRepository;
 import com.backend.immilog.post.model.services.PostInquiryService;
 import com.backend.immilog.user.enums.Countries;
@@ -27,12 +28,18 @@ class PostInquiryServiceTest {
     @Mock
     private PostRepository postRepository;
 
+    @Mock
+    private CommentRepository commentRepository;
+
     private PostInquiryService postInquiryService;
 
     @BeforeEach
     void setUp() {
         MockitoAnnotations.openMocks(this);
-        postInquiryService = new PostInquiryServiceImpl(postRepository);
+        postInquiryService = new PostInquiryServiceImpl(
+                postRepository,
+                commentRepository
+        );
     }
 
     @Test
@@ -73,6 +80,7 @@ class PostInquiryServiceTest {
         Long postSeq = 1L;
         PostDTO postDTO = mock(PostDTO.class);
         when(postRepository.getPost(postSeq)).thenReturn(java.util.Optional.of(postDTO));
+        when(commentRepository.getComments(postSeq)).thenReturn(List.of());
         // when
         PostDTO result = postInquiryService.getPost(postSeq);
         // then


### PR DESCRIPTION
* feat (post) : 게시물 댓글 및 대댓글 작성 기능 추가

* test (post) : 게시물 댓글 및 대댓글 작성 테스트 코드 추가

* feat (post) : 게시물 조회 시 댓글/대댓글 함께 조회하도록 수정

* test (post) : 게시물 조회 시 댓글/대댓글 함께 조회하는 테스트코드 추가

### 작업 내용
- 게시물 댓글 및 대댓글 작성 기능 추가
- 게시물 조회 시 댓글 / 대댓글 함께 조회하도록 수정
- 테스트코드 작성

### 특이 사항
- 없음

