### PR TITLE
feat (global) : Swagger 에서 Token 받는 방식 변경 

### DIFF
--- a/src/main/java/com/backend/immilog/global/configuration/SwaggerConfig.java
+++ b/src/main/java/com/backend/immilog/global/configuration/SwaggerConfig.java
@@ -7,11 +7,13 @@ import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 import springfox.documentation.builders.ApiInfoBuilder;
 import springfox.documentation.builders.PathSelectors;
 import springfox.documentation.builders.RequestHandlerSelectors;
-import springfox.documentation.service.ApiInfo;
-import springfox.documentation.service.Contact;
+import springfox.documentation.service.*;
 import springfox.documentation.spi.DocumentationType;
+import springfox.documentation.spi.service.contexts.SecurityContext;
 import springfox.documentation.spring.web.plugins.Docket;
 import springfox.documentation.swagger2.annotations.EnableSwagger2;
+
+import java.util.List;
 
 @Configuration
 @EnableSwagger2
@@ -24,7 +26,28 @@ public class SwaggerConfig implements WebMvcConfigurer {
                 .apis(RequestHandlerSelectors.basePackage("com.backend.immilog"))
                 .paths(PathSelectors.any())
                 .build()
+                .securitySchemes(List.of(apiKey()))
+                .securityContexts(List.of(securityContext()))
                 .apiInfo(apiInfo());
+    }
+
+    private SecurityContext securityContext() {
+        return SecurityContext.builder()
+                .securityReferences(defaultAuth())
+                .forPaths(PathSelectors.any())
+                .build();
+    }
+
+    private List<SecurityReference> defaultAuth() {
+        AuthorizationScope authorizationScope = new AuthorizationScope("global", "accessEverything");
+        AuthorizationScope[] authorizationScopes = new AuthorizationScope[1];
+        authorizationScopes[0] = authorizationScope;
+        return List.of(new SecurityReference("JWT", authorizationScopes));
+    }
+
+
+    private ApiKey apiKey() {
+        return new ApiKey("JWT", "Authorization", "header");
     }
 
     private ApiInfo apiInfo() {

--- a/src/main/java/com/backend/immilog/global/security/UserIdExtractionAspect.java
+++ b/src/main/java/com/backend/immilog/global/security/UserIdExtractionAspect.java
@@ -2,12 +2,13 @@ package com.backend.immilog.global.security;
 
 import com.backend.immilog.global.enums.UserRole;
 import lombok.RequiredArgsConstructor;
-import org.aspectj.lang.JoinPoint;
 import org.aspectj.lang.annotation.Aspect;
 import org.aspectj.lang.annotation.Before;
 import org.springframework.stereotype.Component;
 
 import javax.servlet.http.HttpServletRequest;
+
+import static org.apache.http.HttpHeaders.AUTHORIZATION;
 
 @Aspect
 @Component
@@ -18,19 +19,16 @@ public class UserIdExtractionAspect {
     private final HttpServletRequest request;
 
     @Before("@annotation(com.backend.immilog.global.security.ExtractUserId)")
-    public void extractUserId(JoinPoint joinPoint) {
-        String authorizationHeader = request.getHeader("Authorization");
-        if (authorizationHeader != null && authorizationHeader.startsWith("Bearer ")) {
-            Long userSeq = tokenProvider.getIdFromToken(authorizationHeader);
-            request.setAttribute("userSeq", userSeq);
-        }
+    public void extractUserId() {
+        String authorizationHeader = request.getHeader(AUTHORIZATION);
+        Long userSeq = tokenProvider.getIdFromToken(authorizationHeader);
+        request.setAttribute("userSeq", userSeq);
     }
+
     @Before("@annotation(com.backend.immilog.global.security.ExtractUserId)")
-    public void extractUserRole(JoinPoint joinPoint) {
-        String authorizationHeader = request.getHeader("Authorization");
-        if (authorizationHeader != null && authorizationHeader.startsWith("Bearer ")) {
-            UserRole userRole = tokenProvider.getUserRoleFromToken(authorizationHeader);
-            request.setAttribute("userRole", userRole);
-        }
+    public void extractUserRole() {
+        String authorizationHeader = request.getHeader(AUTHORIZATION);
+        UserRole userRole = tokenProvider.getUserRoleFromToken(authorizationHeader);
+        request.setAttribute("userRole", userRole);
     }
 }

--- a/src/main/java/com/backend/immilog/user/presentation/controller/UserController.java
+++ b/src/main/java/com/backend/immilog/user/presentation/controller/UserController.java
@@ -36,7 +36,6 @@ public class UserController {
     private final EmailService emailService;
 
     @PostMapping
-    @ExtractUserId
     @ApiOperation(value = "사용자 회원가입", notes = "사용자 회원가입 진행")
     public ResponseEntity<ApiResponse> signUp(
             @Valid @RequestBody UserSignUpRequest request
@@ -52,7 +51,6 @@ public class UserController {
     }
 
     @GetMapping("/{userSeq}/verification")
-    @ExtractUserId
     @ApiOperation(value = "사용자 이메일 인증", notes = "사용자 이메일 인증 진행")
     public String verifyEmail(
             @PathVariable Long userSeq,
@@ -65,7 +63,6 @@ public class UserController {
     }
 
     @PostMapping("/sign-in")
-    @ExtractUserId
     @ApiOperation(value = "사용자 로그인", notes = "사용자 로그인 진행")
     public ResponseEntity<ApiResponse> signIn(
             @Valid @RequestBody UserSignInRequest request
@@ -125,7 +122,6 @@ public class UserController {
     }
 
     @PatchMapping("/{userSeq}/{status}")
-    @ExtractUserId
     @ApiOperation(value = "사용자 차단/해제", notes = "사용자 차단/해제 진행")
     public ResponseEntity<Void> blockUser(
             HttpServletRequest request,


### PR DESCRIPTION
### 작업 내용
- Swagger 에서 Token 받는 방식 변경 
- UserController 에서 불필요하게 사용되던 토큰 검증 어노테이션 제거

### 특이 사항
- `@ExtractUserId` 어노테이션을 통한 검증으로 인해
   Swagger 에서 헤더를 강제하지 않으므로 설정을 수정하여
   선택적으로 입력할 수 있도록 수정
