### PR TITLE
refactor (global) : Exception 및 Country enum 도메인 별로 분리 (#248)

### DIFF
--- a/src/main/java/com/backend/immilog/global/enums/GlobalCountry.java
+++ b/src/main/java/com/backend/immilog/global/enums/GlobalCountry.java
@@ -7,7 +7,7 @@ import java.util.Arrays;
 
 @Getter
 @RequiredArgsConstructor
-public enum Countries {
+public enum GlobalCountry {
     ALL("ALL", "ALL", "전체"),
     MALAYSIA("MALAYSIA", "MY", "말레이시아"),
     SINGAPORE("SINGAPORE", "SG", "싱가포르"),
@@ -33,19 +33,19 @@ public enum Countries {
     private final String countryCode;
     private final String countryKoreanName;
 
-    public static Countries getCountry(
+    public static GlobalCountry getCountry(
             String countryName
     ) {
-        return Arrays.stream(Countries.values())
+        return Arrays.stream(GlobalCountry.values())
                 .filter(country -> country.getCountryName().equals(countryName))
                 .findFirst()
                 .orElse(null);
     }
 
-    public static Countries getCountryByKoreanName(
+    public static GlobalCountry getCountryByKoreanName(
             String countryKoreanName
     ) {
-        return Arrays.stream(Countries.values())
+        return Arrays.stream(GlobalCountry.values())
                 .filter(country -> country.getCountryKoreanName().equals(countryKoreanName))
                 .findFirst()
                 .orElse(null);

--- a/src/main/java/com/backend/immilog/global/security/JwtProvider.java
+++ b/src/main/java/com/backend/immilog/global/security/JwtProvider.java
@@ -1,6 +1,6 @@
 package com.backend.immilog.global.security;
 
-import com.backend.immilog.global.enums.Countries;
+import com.backend.immilog.global.enums.GlobalCountry;
 import com.backend.immilog.global.enums.UserRole;
 import com.backend.immilog.user.application.services.UserDetailsServiceImpl;
 import io.jsonwebtoken.Claims;
@@ -49,7 +49,7 @@ public class JwtProvider implements TokenProvider {
             Long id,
             String email,
             UserRole userRole,
-            Countries country
+            GlobalCountry country
     ) {
         Claims claims =
                 Jwts.claims().setSubject(id.toString());

--- a/src/main/java/com/backend/immilog/global/security/TokenProvider.java
+++ b/src/main/java/com/backend/immilog/global/security/TokenProvider.java
@@ -1,6 +1,6 @@
 package com.backend.immilog.global.security;
 
-import com.backend.immilog.global.enums.Countries;
+import com.backend.immilog.global.enums.GlobalCountry;
 import com.backend.immilog.global.enums.UserRole;
 import org.springframework.security.core.Authentication;
 
@@ -11,7 +11,7 @@ public interface TokenProvider {
             Long id,
             String email,
             UserRole userRole,
-            Countries country
+            GlobalCountry country
     );
 
     String issueRefreshToken();

--- a/src/main/java/com/backend/immilog/notice/application/NoticeInquiryService.java
+++ b/src/main/java/com/backend/immilog/notice/application/NoticeInquiryService.java
@@ -1,7 +1,6 @@
 package com.backend.immilog.notice.application;
 
-import com.backend.immilog.global.exception.CustomException;
-import com.backend.immilog.notice.exception.NoticeErrorCode;
+import com.backend.immilog.notice.exception.NoticeException;
 import com.backend.immilog.notice.model.dtos.NoticeDTO;
 import com.backend.immilog.notice.model.repositories.NoticeRepository;
 import lombok.RequiredArgsConstructor;
@@ -10,7 +9,7 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
-import static com.backend.immilog.notice.exception.NoticeErrorCode.*;
+import static com.backend.immilog.notice.exception.NoticeErrorCode.NOTICE_NOT_FOUND;
 
 @Service
 @RequiredArgsConstructor
@@ -21,7 +20,7 @@ public class NoticeInquiryService {
             Long userSeq,
             Integer page
     ) {
-        if(userSeq == null) {
+        if (userSeq == null) {
             return Page.empty();
         }
         Pageable pageable = PageRequest.of(page, 10);
@@ -34,6 +33,6 @@ public class NoticeInquiryService {
         return noticeRepository
                 .findById(noticeSeq)
                 .map(NoticeDTO::from)
-                .orElseThrow(()-> new CustomException(NOTICE_NOT_FOUND));
+                .orElseThrow(() -> new NoticeException(NOTICE_NOT_FOUND));
     }
 }

--- a/src/main/java/com/backend/immilog/notice/application/NoticeRegisterServiceImpl.java
+++ b/src/main/java/com/backend/immilog/notice/application/NoticeRegisterServiceImpl.java
@@ -1,7 +1,7 @@
 package com.backend.immilog.notice.application;
 
 import com.backend.immilog.global.enums.UserRole;
-import com.backend.immilog.global.exception.CustomException;
+import com.backend.immilog.notice.exception.NoticeException;
 import com.backend.immilog.notice.model.entities.Notice;
 import com.backend.immilog.notice.model.repositories.NoticeRepository;
 import com.backend.immilog.notice.model.services.NoticeRegisterService;
@@ -33,7 +33,7 @@ public class NoticeRegisterServiceImpl implements NoticeRegisterService {
             UserRole userRole
     ) {
         if (!Objects.equals(userRole, ROLE_ADMIN)) {
-            throw new CustomException(NOT_AN_ADMIN_USER);
+            throw new NoticeException(NOT_AN_ADMIN_USER);
         }
     }
 }

--- a/src/main/java/com/backend/immilog/notice/exception/NoticeException.java
+++ b/src/main/java/com/backend/immilog/notice/exception/NoticeException.java
@@ -1,0 +1,10 @@
+package com.backend.immilog.notice.exception;
+
+import com.backend.immilog.global.exception.CustomException;
+import com.backend.immilog.global.exception.ErrorCode;
+
+public class NoticeException extends CustomException {
+    public NoticeException(ErrorCode e) {
+        super(e);
+    }
+}

--- a/src/main/java/com/backend/immilog/notice/model/dtos/NoticeDTO.java
+++ b/src/main/java/com/backend/immilog/notice/model/dtos/NoticeDTO.java
@@ -1,7 +1,7 @@
 package com.backend.immilog.notice.model.dtos;
 
 import com.backend.immilog.notice.model.entities.Notice;
-import com.backend.immilog.notice.model.enums.Countries;
+import com.backend.immilog.notice.model.enums.NoticeCountry;
 import com.backend.immilog.notice.model.enums.NoticeStatus;
 import com.backend.immilog.notice.model.enums.NoticeType;
 import lombok.Builder;
@@ -17,7 +17,7 @@ public record NoticeDTO(
         String content,
         NoticeType type,
         NoticeStatus status,
-        List<Countries> targetCountries,
+        List<NoticeCountry> targetCountries,
         List<Long> readUsers,
         LocalDateTime createdAt
 ) {

--- a/src/main/java/com/backend/immilog/notice/model/entities/Notice.java
+++ b/src/main/java/com/backend/immilog/notice/model/entities/Notice.java
@@ -1,7 +1,7 @@
 package com.backend.immilog.notice.model.entities;
 
 import com.backend.immilog.global.model.BaseDateEntity;
-import com.backend.immilog.notice.model.enums.Countries;
+import com.backend.immilog.notice.model.enums.NoticeCountry;
 import com.backend.immilog.notice.model.enums.NoticeStatus;
 import com.backend.immilog.notice.model.enums.NoticeType;
 import com.backend.immilog.notice.presentation.request.NoticeRegisterRequest;
@@ -42,7 +42,7 @@ public class Notice extends BaseDateEntity {
 
     @ElementCollection(fetch = FetchType.LAZY)
     @Cascade(org.hibernate.annotations.CascadeType.ALL)
-    private List<Countries> targetCountries;
+    private List<NoticeCountry> targetCountries;
 
     @ElementCollection(fetch = FetchType.LAZY)
     @Cascade(org.hibernate.annotations.CascadeType.ALL)

--- a/src/main/java/com/backend/immilog/notice/model/enums/NoticeCountry.java
+++ b/src/main/java/com/backend/immilog/notice/model/enums/NoticeCountry.java
@@ -1,5 +1,6 @@
 package com.backend.immilog.notice.model.enums;
 
+import com.backend.immilog.global.enums.GlobalCountry;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
@@ -7,7 +8,7 @@ import java.util.Arrays;
 
 @Getter
 @RequiredArgsConstructor
-public enum Countries {
+public enum NoticeCountry {
     ALL("ALL","ALL", "전체"),
     MALAYSIA("MALAYSIA","MY","말레이시아"),
     SINGAPORE("SINGAPORE","SG","싱가포르"),
@@ -33,21 +34,25 @@ public enum Countries {
     private final String countryCode;
     private final String countryKoreanName;
 
-    public static Countries getCountry(
+    public static NoticeCountry getCountry(
             String countryName
     ) {
-        return Arrays.stream(Countries.values())
+        return Arrays.stream(NoticeCountry.values())
                 .filter(country -> country.getCountryName().equals(countryName))
                 .findFirst()
                 .orElse(null);
     }
 
-    public static Countries getCountryByKoreanName(
+    public static NoticeCountry getCountryByKoreanName(
             String countryKoreanName
     ) {
-        return Arrays.stream(Countries.values())
+        return Arrays.stream(NoticeCountry.values())
                 .filter(country -> country.getCountryKoreanName().equals(countryKoreanName))
                 .findFirst()
                 .orElse(null);
+    }
+
+    public GlobalCountry toGlobalCountries() {
+        return GlobalCountry.valueOf(this.name());
     }
 }

--- a/src/main/java/com/backend/immilog/notice/presentation/request/NoticeRegisterRequest.java
+++ b/src/main/java/com/backend/immilog/notice/presentation/request/NoticeRegisterRequest.java
@@ -1,6 +1,6 @@
 package com.backend.immilog.notice.presentation.request;
 
-import com.backend.immilog.notice.model.enums.Countries;
+import com.backend.immilog.notice.model.enums.NoticeCountry;
 import com.backend.immilog.notice.model.enums.NoticeType;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -17,5 +17,5 @@ public class NoticeRegisterRequest {
     private String title;
     private String content;
     private NoticeType type;
-    private List<Countries> targetCountries;
+    private List<NoticeCountry> targetCountries;
 }

--- a/src/main/java/com/backend/immilog/post/application/CommentUploadServiceImpl.java
+++ b/src/main/java/com/backend/immilog/post/application/CommentUploadServiceImpl.java
@@ -1,6 +1,6 @@
 package com.backend.immilog.post.application;
 
-import com.backend.immilog.global.exception.CustomException;
+import com.backend.immilog.post.exception.PostException;
 import com.backend.immilog.post.model.entities.Comment;
 import com.backend.immilog.post.model.entities.Post;
 import com.backend.immilog.post.model.enums.ReferenceType;
@@ -48,6 +48,6 @@ public class CommentUploadServiceImpl implements CommentUploadService {
     ) {
         return postRepository
                 .findById(postSeq)
-                .orElseThrow(() -> new CustomException(POST_NOT_FOUND));
+                .orElseThrow(() -> new PostException(POST_NOT_FOUND));
     }
 }

--- a/src/main/java/com/backend/immilog/post/application/PostDeleteServiceImpl.java
+++ b/src/main/java/com/backend/immilog/post/application/PostDeleteServiceImpl.java
@@ -1,6 +1,6 @@
 package com.backend.immilog.post.application;
 
-import com.backend.immilog.global.exception.CustomException;
+import com.backend.immilog.post.exception.PostException;
 import com.backend.immilog.post.model.entities.Post;
 import com.backend.immilog.post.model.repositories.PostRepository;
 import com.backend.immilog.post.model.repositories.PostResourceRepository;
@@ -43,7 +43,7 @@ public class PostDeleteServiceImpl implements PostDeleteService {
             Long postSeq
     ) {
         return postRepository.findById(postSeq)
-                .orElseThrow(() -> new CustomException(POST_NOT_FOUND));
+                .orElseThrow(() -> new PostException(POST_NOT_FOUND));
     }
 
     private void validateAuthor(
@@ -51,7 +51,7 @@ public class PostDeleteServiceImpl implements PostDeleteService {
             Post post
     ) {
         if (!Objects.equals(post.getPostUserData().getUserSeq(), userId)) {
-            throw new CustomException(NO_AUTHORITY);
+            throw new PostException(NO_AUTHORITY);
         }
     }
 }

--- a/src/main/java/com/backend/immilog/post/application/PostInquiryServiceImpl.java
+++ b/src/main/java/com/backend/immilog/post/application/PostInquiryServiceImpl.java
@@ -1,6 +1,6 @@
 package com.backend.immilog.post.application;
 
-import com.backend.immilog.global.exception.CustomException;
+import com.backend.immilog.post.exception.PostException;
 import com.backend.immilog.post.model.dtos.CommentDTO;
 import com.backend.immilog.post.model.dtos.PostDTO;
 import com.backend.immilog.post.model.enums.Categories;
@@ -79,6 +79,6 @@ public class PostInquiryServiceImpl implements PostInquiryService {
     private PostDTO getPostDTO(Long postSeq) {
         return postRepository
                 .getPost(postSeq)
-                .orElseThrow(() -> new CustomException(POST_NOT_FOUND));
+                .orElseThrow(() -> new PostException(POST_NOT_FOUND));
     }
 }

--- a/src/main/java/com/backend/immilog/post/application/PostUpdateServiceImpl.java
+++ b/src/main/java/com/backend/immilog/post/application/PostUpdateServiceImpl.java
@@ -1,7 +1,7 @@
 package com.backend.immilog.post.application;
 
 import com.backend.immilog.global.application.RedisDistributedLock;
-import com.backend.immilog.global.exception.CustomException;
+import com.backend.immilog.post.exception.PostException;
 import com.backend.immilog.post.model.entities.InteractionUser;
 import com.backend.immilog.post.model.entities.Post;
 import com.backend.immilog.post.model.enums.ResourceType;
@@ -172,7 +172,7 @@ public class PostUpdateServiceImpl implements PostUpdateService {
                             ps.setString(4, resource);
                         } catch (Exception e) {
                             log.error("Failed to save post resource", e);
-                            throw new CustomException(FAILED_TO_SAVE_POST);
+                            throw new PostException(FAILED_TO_SAVE_POST);
                         }
                     }
             );
@@ -199,7 +199,7 @@ public class PostUpdateServiceImpl implements PostUpdateService {
             Post post
     ) {
         if (!Objects.equals(post.getPostUserData().getUserSeq(), userId)) {
-            throw new CustomException(NO_AUTHORITY);
+            throw new PostException(NO_AUTHORITY);
         }
     }
 
@@ -207,6 +207,6 @@ public class PostUpdateServiceImpl implements PostUpdateService {
             Long postSeq
     ) {
         return postRepository.findById(postSeq)
-                .orElseThrow(() -> new CustomException(POST_NOT_FOUND));
+                .orElseThrow(() -> new PostException(POST_NOT_FOUND));
     }
 }

--- a/src/main/java/com/backend/immilog/post/application/PostUploadServiceImpl.java
+++ b/src/main/java/com/backend/immilog/post/application/PostUploadServiceImpl.java
@@ -1,6 +1,6 @@
 package com.backend.immilog.post.application;
 
-import com.backend.immilog.global.exception.CustomException;
+import com.backend.immilog.post.exception.PostException;
 import com.backend.immilog.post.model.entities.Post;
 import com.backend.immilog.post.model.entities.PostResource;
 import com.backend.immilog.post.model.repositories.BulkInsertRepository;
@@ -82,7 +82,7 @@ public class PostUploadServiceImpl implements PostUploadService {
                         ps.setString(4, postResource.getContent());
                     } catch (SQLException e) {
                         log.error("Failed to save post resource: {}", e.getMessage());
-                        throw new CustomException(FAILED_TO_SAVE_POST);
+                        throw new PostException(FAILED_TO_SAVE_POST);
                     }
                 }
         );
@@ -131,7 +131,7 @@ public class PostUploadServiceImpl implements PostUploadService {
     ) {
         return userRepository
                 .findById(userSeq)
-                .orElseThrow(() -> new CustomException(USER_NOT_FOUND));
+                .orElseThrow(() -> new PostException(USER_NOT_FOUND));
     }
 
 }

--- a/src/main/java/com/backend/immilog/post/exception/PostException.java
+++ b/src/main/java/com/backend/immilog/post/exception/PostException.java
@@ -1,0 +1,10 @@
+package com.backend.immilog.post.exception;
+
+import com.backend.immilog.global.exception.CustomException;
+import com.backend.immilog.global.exception.ErrorCode;
+
+public class PostException extends CustomException {
+    public PostException(ErrorCode e) {
+        super(e);
+    }
+}

--- a/src/main/java/com/backend/immilog/post/model/enums/ReferenceType.java
+++ b/src/main/java/com/backend/immilog/post/model/enums/ReferenceType.java
@@ -1,6 +1,6 @@
 package com.backend.immilog.post.model.enums;
 
-import com.backend.immilog.global.exception.CustomException;
+import com.backend.immilog.post.exception.PostException;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
@@ -22,6 +22,6 @@ public enum ReferenceType {
         return Arrays.stream(values())
                 .filter(type -> type.stringValue.equals(referenceType))
                 .findFirst()
-                .orElseThrow(() -> new CustomException(INVALID_REFERENCE_TYPE));
+                .orElseThrow(() -> new PostException(INVALID_REFERENCE_TYPE));
     }
 }

--- a/src/main/java/com/backend/immilog/user/application/command/UserInfoUpdateCommand.java
+++ b/src/main/java/com/backend/immilog/user/application/command/UserInfoUpdateCommand.java
@@ -1,6 +1,6 @@
 package com.backend.immilog.user.application.command;
 
-import com.backend.immilog.global.enums.Countries;
+import com.backend.immilog.user.model.enums.UserCountry;
 import com.backend.immilog.user.model.enums.UserStatus;
 import lombok.Builder;
 
@@ -8,8 +8,8 @@ import lombok.Builder;
 public record UserInfoUpdateCommand(
         String nickName,
         String profileImage,
-        Countries country,
-        Countries interestCountry,
+        UserCountry country,
+        UserCountry interestCountry,
         Double latitude,
         Double longitude,
         UserStatus status

--- a/src/main/java/com/backend/immilog/user/application/services/EmailServiceImpl.java
+++ b/src/main/java/com/backend/immilog/user/application/services/EmailServiceImpl.java
@@ -1,6 +1,6 @@
 package com.backend.immilog.user.application.services;
 
-import com.backend.immilog.global.exception.CustomException;
+import com.backend.immilog.user.exception.UserException;
 import com.backend.immilog.user.model.services.EmailService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -35,7 +35,7 @@ public class EmailServiceImpl implements EmailService {
             helper.setText(htmlBody, true);  // true는 HTML을 의미함
         } catch (MessagingException e) {
             log.error("Failed to send email", e);
-            throw new CustomException(EMAIL_SEND_FAILED);
+            throw new UserException(EMAIL_SEND_FAILED);
         }
 
         javaMailSender.send(message);

--- a/src/main/java/com/backend/immilog/user/application/services/LocationServiceImpl.java
+++ b/src/main/java/com/backend/immilog/user/application/services/LocationServiceImpl.java
@@ -1,6 +1,6 @@
 package com.backend.immilog.user.application.services;
 
-import com.backend.immilog.global.enums.Countries;
+import com.backend.immilog.global.enums.GlobalCountry;
 import com.backend.immilog.user.model.services.LocationService;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -45,7 +45,7 @@ public class LocationServiceImpl implements LocationService {
             String compoundCode = extractCompoundCode(response.join());
             String[] parts = Objects.requireNonNull(compoundCode).split(" ");
             if (parts.length >= 3) {
-                String country = Countries.getCountryByKoreanName(parts[1]).getCountryName();
+                String country = GlobalCountry.getCountryByKoreanName(parts[1]).getCountryName();
                 String city = parts[2];
                 return CompletableFuture.completedFuture(Pair.of(country, city));
             }

--- a/src/main/java/com/backend/immilog/user/application/services/UserDetailsServiceImpl.java
+++ b/src/main/java/com/backend/immilog/user/application/services/UserDetailsServiceImpl.java
@@ -1,6 +1,6 @@
 package com.backend.immilog.user.application.services;
 
-import com.backend.immilog.global.exception.CustomException;
+import com.backend.immilog.user.exception.UserException;
 import com.backend.immilog.user.model.repositories.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.GrantedAuthority;
@@ -41,6 +41,6 @@ public class UserDetailsServiceImpl implements UserDetailsService {
     ) {
         return userRepository
                 .findByEmail(email)
-                .orElseThrow(() -> new CustomException(USER_NOT_FOUND));
+                .orElseThrow(() -> new UserException(USER_NOT_FOUND));
     }
 }

--- a/src/main/java/com/backend/immilog/user/application/services/UserInformationServiceImpl.java
+++ b/src/main/java/com/backend/immilog/user/application/services/UserInformationServiceImpl.java
@@ -1,11 +1,11 @@
 package com.backend.immilog.user.application.services;
 
 import com.backend.immilog.global.application.ImageService;
-import com.backend.immilog.global.enums.Countries;
-import com.backend.immilog.global.exception.CustomException;
 import com.backend.immilog.user.application.command.UserInfoUpdateCommand;
 import com.backend.immilog.user.application.command.UserPasswordChangeCommand;
+import com.backend.immilog.user.exception.UserException;
 import com.backend.immilog.user.model.entities.User;
+import com.backend.immilog.user.model.enums.UserCountry;
 import com.backend.immilog.user.model.enums.UserStatus;
 import com.backend.immilog.user.model.repositories.UserRepository;
 import com.backend.immilog.user.model.services.UserInformationService;
@@ -71,7 +71,7 @@ public class UserInformationServiceImpl implements UserInformationService {
             Long userSeq
     ) {
         if (!getUser(userSeq).getUserRole().equals(ROLE_ADMIN)) {
-            throw new CustomException(NOT_AN_ADMIN_USER);
+            throw new UserException(NOT_AN_ADMIN_USER);
         }
         ;
     }
@@ -81,7 +81,7 @@ public class UserInformationServiceImpl implements UserInformationService {
             String currentPassword
     ) {
         if (!passwordEncoder.matches(existingPassword, currentPassword)) {
-            throw new CustomException(PASSWORD_NOT_MATCH);
+            throw new UserException(PASSWORD_NOT_MATCH);
         }
     }
 
@@ -111,7 +111,7 @@ public class UserInformationServiceImpl implements UserInformationService {
     }
 
     private static void setUserInterestCountryIfItsChanged(
-            Countries interestCountry,
+            UserCountry interestCountry,
             User user
     ) {
         if (interestCountry != null) {
@@ -142,7 +142,7 @@ public class UserInformationServiceImpl implements UserInformationService {
             Long userSeq
     ) {
         return userRepository.findById(userSeq)
-                .orElseThrow(() -> new CustomException(USER_NOT_FOUND));
+                .orElseThrow(() -> new UserException(USER_NOT_FOUND));
     }
 
 }

--- a/src/main/java/com/backend/immilog/user/application/services/UserReportServiceImpl.java
+++ b/src/main/java/com/backend/immilog/user/application/services/UserReportServiceImpl.java
@@ -1,8 +1,8 @@
 package com.backend.immilog.user.application.services;
 
 import com.backend.immilog.global.application.RedisDistributedLock;
-import com.backend.immilog.global.exception.CustomException;
 import com.backend.immilog.user.application.command.UserReportCommand;
+import com.backend.immilog.user.exception.UserException;
 import com.backend.immilog.user.model.entities.Report;
 import com.backend.immilog.user.model.entities.User;
 import com.backend.immilog.user.model.repositories.ReportRepository;
@@ -91,7 +91,7 @@ public class UserReportServiceImpl implements UserReportService {
             Long reporterUserSeq
     ) {
         if (targetUserSeq.equals(reporterUserSeq)) {
-            throw new CustomException(CANNOT_REPORT_MYSELF);
+            throw new UserException(CANNOT_REPORT_MYSELF);
         }
     }
 
@@ -104,7 +104,7 @@ public class UserReportServiceImpl implements UserReportService {
                         targetUserSeq, reporterUserSeq
                 );
         if (isExist) {
-            throw new CustomException(ALREADY_REPORTED);
+            throw new UserException(ALREADY_REPORTED);
         }
     }
 
@@ -113,6 +113,6 @@ public class UserReportServiceImpl implements UserReportService {
     ) {
         return userRepository
                 .findById(targetUserSeq)
-                .orElseThrow(() -> new CustomException(USER_NOT_FOUND));
+                .orElseThrow(() -> new UserException(USER_NOT_FOUND));
     }
 }

--- a/src/main/java/com/backend/immilog/user/application/services/UserSignInServiceImpl.java
+++ b/src/main/java/com/backend/immilog/user/application/services/UserSignInServiceImpl.java
@@ -1,9 +1,9 @@
 package com.backend.immilog.user.application.services;
 
 import com.backend.immilog.global.application.RedisService;
-import com.backend.immilog.global.exception.CustomException;
 import com.backend.immilog.global.security.TokenProvider;
 import com.backend.immilog.user.application.command.UserSignInCommand;
+import com.backend.immilog.user.exception.UserException;
 import com.backend.immilog.user.model.dtos.UserSignInDTO;
 import com.backend.immilog.user.model.embeddables.Location;
 import com.backend.immilog.user.model.entities.User;
@@ -43,7 +43,7 @@ public class UserSignInServiceImpl implements UserSignInService {
                 user.getSeq(),
                 user.getEmail(),
                 user.getUserRole(),
-                user.getLocation().getCountry()
+                user.getLocation().getCountry().toGlobalCountries()
         );
 
         String refreshToken = tokenProvider.issueRefreshToken();
@@ -74,7 +74,7 @@ public class UserSignInServiceImpl implements UserSignInService {
                 user.getSeq(),
                 user.getEmail(),
                 user.getUserRole(),
-                user.getLocation().getCountry()
+                user.getLocation().getCountry().toGlobalCountries()
         );
         final String refreshToken = tokenProvider.issueRefreshToken();
 
@@ -116,7 +116,7 @@ public class UserSignInServiceImpl implements UserSignInService {
             User user
     ) {
         if (!user.getUserStatus().equals(UserStatus.ACTIVE)) {
-            throw new CustomException(USER_STATUS_NOT_ACTIVE);
+            throw new UserException(USER_STATUS_NOT_ACTIVE);
         }
     }
 
@@ -125,19 +125,19 @@ public class UserSignInServiceImpl implements UserSignInService {
             User user
     ) {
         if (!passwordEncoder.matches(userSignInCommand.password(), user.getPassword())) {
-            throw new CustomException(PASSWORD_NOT_MATCH);
+            throw new UserException(PASSWORD_NOT_MATCH);
         }
     }
 
     private User getUser(String email) {
         return userRepository
                 .findByEmail(email)
-                .orElseThrow(() -> new CustomException(USER_NOT_FOUND));
+                .orElseThrow(() -> new UserException(USER_NOT_FOUND));
     }
 
     private User getUser(Long id) {
         return userRepository
                 .findById(id)
-                .orElseThrow(() -> new CustomException(USER_NOT_FOUND));
+                .orElseThrow(() -> new UserException(USER_NOT_FOUND));
     }
 }

--- a/src/main/java/com/backend/immilog/user/application/services/UserSignUpServiceImpl.java
+++ b/src/main/java/com/backend/immilog/user/application/services/UserSignUpServiceImpl.java
@@ -1,9 +1,9 @@
 package com.backend.immilog.user.application.services;
 
-import com.backend.immilog.global.exception.CustomException;
 import com.backend.immilog.user.application.command.UserSignUpCommand;
-import com.backend.immilog.user.model.enums.UserStatus;
+import com.backend.immilog.user.exception.UserException;
 import com.backend.immilog.user.model.entities.User;
+import com.backend.immilog.user.model.enums.UserStatus;
 import com.backend.immilog.user.model.repositories.UserRepository;
 import com.backend.immilog.user.model.services.UserSignUpService;
 import lombok.RequiredArgsConstructor;
@@ -12,9 +12,9 @@ import org.springframework.data.util.Pair;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 
-import static com.backend.immilog.user.model.enums.UserStatus.ACTIVE;
 import static com.backend.immilog.user.exception.UserErrorCode.EXISTING_USER;
 import static com.backend.immilog.user.exception.UserErrorCode.USER_NOT_FOUND;
+import static com.backend.immilog.user.model.enums.UserStatus.ACTIVE;
 
 @Slf4j
 @RequiredArgsConstructor
@@ -45,7 +45,7 @@ public class UserSignUpServiceImpl implements UserSignUpService {
             Long userSeq
     ) {
         User user = userRepository.findById(userSeq)
-                .orElseThrow(() -> new CustomException(USER_NOT_FOUND));
+                .orElseThrow(() -> new UserException(USER_NOT_FOUND));
         String resultString = "이메일 인증이 완료되었습니다.";
         UserStatus currentUserStatus = user.getUserStatus();
         return getVerificationResult(currentUserStatus, user, resultString);
@@ -57,7 +57,7 @@ public class UserSignUpServiceImpl implements UserSignUpService {
         userRepository
                 .findByEmail(email)
                 .ifPresent(user -> {
-                    throw new CustomException(EXISTING_USER);
+                    throw new UserException(EXISTING_USER);
                 });
     }
 

--- a/src/main/java/com/backend/immilog/user/exception/UserException.java
+++ b/src/main/java/com/backend/immilog/user/exception/UserException.java
@@ -1,0 +1,10 @@
+package com.backend.immilog.user.exception;
+
+import com.backend.immilog.global.exception.CustomException;
+import com.backend.immilog.global.exception.ErrorCode;
+
+public class UserException extends CustomException {
+    public UserException(ErrorCode e) {
+        super(e);
+    }
+}

--- a/src/main/java/com/backend/immilog/user/model/dtos/UserDTO.java
+++ b/src/main/java/com/backend/immilog/user/model/dtos/UserDTO.java
@@ -1,8 +1,8 @@
 package com.backend.immilog.user.model.dtos;
 
-import com.backend.immilog.global.enums.Countries;
 import com.backend.immilog.global.enums.UserRole;
 import com.backend.immilog.user.model.entities.User;
+import com.backend.immilog.user.model.enums.UserCountry;
 import com.backend.immilog.user.model.enums.UserStatus;
 import lombok.Builder;
 
@@ -16,8 +16,8 @@ public record UserDTO(
         String profileImage,
         Long reportedCount,
         Date reportedDate,
-        Countries country,
-        Countries interestCountry,
+        UserCountry country,
+        UserCountry interestCountry,
         String region,
         UserRole userRole,
         UserStatus userStatus

--- a/src/main/java/com/backend/immilog/user/model/embeddables/Location.java
+++ b/src/main/java/com/backend/immilog/user/model/embeddables/Location.java
@@ -1,6 +1,6 @@
 package com.backend.immilog.user.model.embeddables;
 
-import com.backend.immilog.global.enums.Countries;
+import com.backend.immilog.user.model.enums.UserCountry;
 import lombok.*;
 
 import javax.persistence.Embeddable;
@@ -15,11 +15,11 @@ import javax.persistence.Enumerated;
 @Embeddable
 public class Location {
     @Enumerated(EnumType.STRING)
-    private Countries country;
+    private UserCountry country;
     private String region;
 
     public static Location of(
-            Countries country,
+            UserCountry country,
             String region
     ) {
         return Location.builder()

--- a/src/main/java/com/backend/immilog/user/model/entities/User.java
+++ b/src/main/java/com/backend/immilog/user/model/entities/User.java
@@ -1,6 +1,6 @@
 package com.backend.immilog.user.model.entities;
 
-import com.backend.immilog.global.enums.Countries;
+import com.backend.immilog.user.model.enums.UserCountry;
 import com.backend.immilog.global.enums.UserRole;
 import com.backend.immilog.global.model.BaseDateEntity;
 import com.backend.immilog.user.application.command.UserSignUpCommand;
@@ -44,7 +44,7 @@ public class User extends BaseDateEntity {
 
     @Setter
     @Enumerated(EnumType.STRING)
-    private Countries interestCountry;
+    private UserCountry interestCountry;
 
     @Embedded
     private Location location;
@@ -56,10 +56,10 @@ public class User extends BaseDateEntity {
             UserSignUpCommand userSignUpCommand,
             String encodedPassword
     ) {
-        Countries interestCountry =
+        UserCountry interestCountry =
                 userSignUpCommand.interestCountry() != null ?
-                        Countries.getCountry(userSignUpCommand.interestCountry()) : null;
-        Countries country = Countries.getCountryByKoreanName(userSignUpCommand.country());
+                        UserCountry.getCountry(userSignUpCommand.interestCountry()) : null;
+        UserCountry country = UserCountry.getCountryByKoreanName(userSignUpCommand.country());
 
         return User.builder()
                 .nickName(userSignUpCommand.nickName())

--- a/src/main/java/com/backend/immilog/user/model/enums/UserCountry.java
+++ b/src/main/java/com/backend/immilog/user/model/enums/UserCountry.java
@@ -1,4 +1,4 @@
-package com.backend.immilog.post.model.enums;
+package com.backend.immilog.user.model.enums;
 
 import com.backend.immilog.global.enums.GlobalCountry;
 import lombok.Getter;
@@ -8,7 +8,7 @@ import java.util.Arrays;
 
 @Getter
 @RequiredArgsConstructor
-public enum Countries {
+public enum UserCountry {
     ALL("ALL","ALL", "전체"),
     MALAYSIA("MALAYSIA","MY","말레이시아"),
     SINGAPORE("SINGAPORE","SG","싱가포르"),
@@ -34,19 +34,19 @@ public enum Countries {
     private final String countryCode;
     private final String countryKoreanName;
 
-    public static Countries getCountry(
+    public static UserCountry getCountry(
             String countryName
     ) {
-        return Arrays.stream(Countries.values())
+        return Arrays.stream(UserCountry.values())
                 .filter(country -> country.getCountryName().equals(countryName))
                 .findFirst()
                 .orElse(null);
     }
 
-    public static Countries getCountryByKoreanName(
+    public static UserCountry getCountryByKoreanName(
             String countryKoreanName
     ) {
-        return Arrays.stream(Countries.values())
+        return Arrays.stream(UserCountry.values())
                 .filter(country -> country.getCountryKoreanName().equals(countryKoreanName))
                 .findFirst()
                 .orElse(null);

--- a/src/main/java/com/backend/immilog/user/presentation/controller/LocationController.java
+++ b/src/main/java/com/backend/immilog/user/presentation/controller/LocationController.java
@@ -1,6 +1,6 @@
 package com.backend.immilog.user.presentation.controller;
 
-import com.backend.immilog.global.enums.Countries;
+import com.backend.immilog.global.enums.GlobalCountry;
 import com.backend.immilog.global.presentation.response.ApiResponse;
 import com.backend.immilog.user.model.services.LocationService;
 import com.backend.immilog.user.presentation.response.LocationResponse;
@@ -39,7 +39,7 @@ public class LocationController {
                 .status(OK)
                 .body(ApiResponse.of(
                                 LocationResponse.from(
-                                        Countries.getCountryByKoreanName(country.getFirst()),
+                                        GlobalCountry.getCountryByKoreanName(country.getFirst()),
                                         country.getSecond()
                                 )
                         )

--- a/src/main/java/com/backend/immilog/user/presentation/request/UserInfoUpdateRequest.java
+++ b/src/main/java/com/backend/immilog/user/presentation/request/UserInfoUpdateRequest.java
@@ -1,7 +1,7 @@
 package com.backend.immilog.user.presentation.request;
 
-import com.backend.immilog.global.enums.Countries;
 import com.backend.immilog.user.application.command.UserInfoUpdateCommand;
+import com.backend.immilog.user.model.enums.UserCountry;
 import com.backend.immilog.user.model.enums.UserStatus;
 import io.swagger.annotations.ApiModel;
 import lombok.Builder;
@@ -11,8 +11,8 @@ import lombok.Builder;
 public record UserInfoUpdateRequest(
         String nickName,
         String profileImage,
-        Countries country,
-        Countries interestCountry,
+        UserCountry country,
+        UserCountry interestCountry,
         Double latitude,
         Double longitude,
         UserStatus status

--- a/src/main/java/com/backend/immilog/user/presentation/response/LocationResponse.java
+++ b/src/main/java/com/backend/immilog/user/presentation/response/LocationResponse.java
@@ -1,6 +1,6 @@
 package com.backend.immilog.user.presentation.response;
 
-import com.backend.immilog.global.enums.Countries;
+import com.backend.immilog.global.enums.GlobalCountry;
 import lombok.Builder;
 
 @Builder
@@ -9,7 +9,7 @@ public record LocationResponse(
         String region
 ) {
     public static LocationResponse from(
-            Countries country,
+            GlobalCountry country,
             String region
     ) {
         return LocationResponse.builder()

--- a/src/test/java/com/backend/immilog/global/security/JwtProviderTest.java
+++ b/src/test/java/com/backend/immilog/global/security/JwtProviderTest.java
@@ -1,6 +1,6 @@
 package com.backend.immilog.global.security;
 
-import com.backend.immilog.global.enums.Countries;
+import com.backend.immilog.global.enums.GlobalCountry;
 import com.backend.immilog.global.enums.UserRole;
 import com.backend.immilog.user.application.services.UserDetailsServiceImpl;
 import io.jsonwebtoken.Claims;
@@ -52,7 +52,7 @@ class JwtProviderTest {
                 1L,
                 "test@example.com",
                 UserRole.ROLE_USER,
-                Countries.SOUTH_KOREA
+                GlobalCountry.SOUTH_KOREA
         );
         assertNotNull(token);
 
@@ -89,7 +89,7 @@ class JwtProviderTest {
                 1L,
                 "test@example.com",
                 UserRole.ROLE_USER,
-                Countries.SOUTH_KOREA
+                GlobalCountry.SOUTH_KOREA
         );
 
         boolean isValid = tokenProvider.validateToken(token);
@@ -111,7 +111,7 @@ class JwtProviderTest {
                 1L,
                 "test@example.com",
                 UserRole.ROLE_USER,
-                Countries.SOUTH_KOREA
+                GlobalCountry.SOUTH_KOREA
         );
 
         Long id = tokenProvider.getIdFromToken(token);
@@ -125,7 +125,7 @@ class JwtProviderTest {
                 1L,
                 "test@example.com",
                 UserRole.ROLE_USER,
-                Countries.SOUTH_KOREA
+                GlobalCountry.SOUTH_KOREA
         );
 
         String email = tokenProvider.getEmailFromToken(token);
@@ -139,7 +139,7 @@ class JwtProviderTest {
                 1L,
                 "test@example.com",
                 UserRole.ROLE_USER,
-                Countries.SOUTH_KOREA
+                GlobalCountry.SOUTH_KOREA
         );
 
         UserDetails mockUserDetails = mock(UserDetails.class);

--- a/src/test/java/com/backend/immilog/notice/application/NoticeInquiryServiceTest.java
+++ b/src/test/java/com/backend/immilog/notice/application/NoticeInquiryServiceTest.java
@@ -15,7 +15,7 @@ import org.springframework.data.domain.PageRequest;
 
 import java.util.List;
 
-import static com.backend.immilog.notice.model.enums.Countries.SOUTH_KOREA;
+import static com.backend.immilog.notice.model.enums.NoticeCountry.SOUTH_KOREA;
 import static com.backend.immilog.notice.model.enums.NoticeStatus.NORMAL;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.when;

--- a/src/test/java/com/backend/immilog/post/application/CommentUploadServiceImplTest.java
+++ b/src/test/java/com/backend/immilog/post/application/CommentUploadServiceImplTest.java
@@ -1,6 +1,6 @@
 package com.backend.immilog.post.application;
 
-import com.backend.immilog.global.exception.CustomException;
+import com.backend.immilog.post.exception.PostException;
 import com.backend.immilog.post.model.entities.Post;
 import com.backend.immilog.post.model.repositories.CommentRepository;
 import com.backend.immilog.post.model.repositories.PostRepository;
@@ -76,7 +76,7 @@ class CommentUploadServiceImplTest {
                 referenceType,
                 commentUploadRequest
         ))
-                .isInstanceOf(CustomException.class)
+                .isInstanceOf(PostException.class)
                 .hasMessage(POST_NOT_FOUND.getMessage());
     }
 
@@ -98,7 +98,7 @@ class CommentUploadServiceImplTest {
                 referenceType,
                 commentUploadRequest
         ))
-                .isInstanceOf(CustomException.class)
+                .isInstanceOf(PostException.class)
                 .hasMessage(INVALID_REFERENCE_TYPE.getMessage());
     }
 

--- a/src/test/java/com/backend/immilog/post/application/PostDeleteServiceTest.java
+++ b/src/test/java/com/backend/immilog/post/application/PostDeleteServiceTest.java
@@ -1,6 +1,6 @@
 package com.backend.immilog.post.application;
 
-import com.backend.immilog.global.exception.CustomException;
+import com.backend.immilog.post.exception.PostException;
 import com.backend.immilog.post.model.embeddables.PostMetaData;
 import com.backend.immilog.post.model.embeddables.PostUserData;
 import com.backend.immilog.post.model.entities.Post;
@@ -15,8 +15,8 @@ import org.mockito.MockitoAnnotations;
 
 import java.util.Optional;
 
-import static com.backend.immilog.post.model.enums.PostStatus.DELETED;
 import static com.backend.immilog.post.exception.PostErrorCode.NO_AUTHORITY;
+import static com.backend.immilog.post.model.enums.PostStatus.DELETED;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.verify;
@@ -76,7 +76,7 @@ class PostDeleteServiceTest {
 
         // when & then
         assertThatThrownBy(() -> postDeleteService.deletePost(userId, postSeq))
-                .isInstanceOf(CustomException.class)
+                .isInstanceOf(PostException.class)
                 .hasMessage(NO_AUTHORITY.getMessage());
 
     }

--- a/src/test/java/com/backend/immilog/post/application/PostUpdateServiceTest.java
+++ b/src/test/java/com/backend/immilog/post/application/PostUpdateServiceTest.java
@@ -1,7 +1,7 @@
 package com.backend.immilog.post.application;
 
 import com.backend.immilog.global.application.RedisDistributedLock;
-import com.backend.immilog.global.exception.CustomException;
+import com.backend.immilog.post.exception.PostException;
 import com.backend.immilog.post.model.embeddables.PostMetaData;
 import com.backend.immilog.post.model.embeddables.PostUserData;
 import com.backend.immilog.post.model.entities.InteractionUser;
@@ -149,7 +149,7 @@ class PostUpdateServiceTest {
         // when & then
         assertThatThrownBy(() ->
                 postUpdateService.updatePost(userSeq, postSeq, postUpdateRequest))
-                .isInstanceOf(CustomException.class)
+                .isInstanceOf(PostException.class)
                 .hasMessage(FAILED_TO_SAVE_POST.getMessage());
 
         verify(bulkInsertRepository).saveAll(anyList(), anyString(), any(BiConsumer.class));

--- a/src/test/java/com/backend/immilog/post/application/PostUploadServiceTest.java
+++ b/src/test/java/com/backend/immilog/post/application/PostUploadServiceTest.java
@@ -1,7 +1,6 @@
 package com.backend.immilog.post.application;
 
-import com.backend.immilog.global.enums.Countries;
-import com.backend.immilog.global.exception.CustomException;
+import com.backend.immilog.post.exception.PostException;
 import com.backend.immilog.post.model.entities.Post;
 import com.backend.immilog.post.model.entities.PostResource;
 import com.backend.immilog.post.model.enums.Categories;
@@ -11,6 +10,7 @@ import com.backend.immilog.post.model.services.PostUploadService;
 import com.backend.immilog.post.presentation.request.PostUploadRequest;
 import com.backend.immilog.user.model.embeddables.Location;
 import com.backend.immilog.user.model.entities.User;
+import com.backend.immilog.user.model.enums.UserCountry;
 import com.backend.immilog.user.model.repositories.UserRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -76,7 +76,7 @@ class PostUploadServiceTest {
                 .content("content")
                 .build();
         Location location = Location.builder()
-                .country(Countries.SOUTH_KOREA)
+                .country(UserCountry.SOUTH_KOREA)
                 .region("region")
                 .build();
         User user = User.builder()
@@ -132,7 +132,7 @@ class PostUploadServiceTest {
                 .content("content")
                 .build();
         Location location = Location.builder()
-                .country(Countries.SOUTH_KOREA)
+                .country(UserCountry.SOUTH_KOREA)
                 .region("region")
                 .build();
         User user = User.builder()
@@ -165,7 +165,7 @@ class PostUploadServiceTest {
                 .content("content")
                 .build();
         Location location = Location.builder()
-                .country(Countries.SOUTH_KOREA)
+                .country(UserCountry.SOUTH_KOREA)
                 .region("region")
                 .build();
         User user = User.builder()
@@ -187,7 +187,7 @@ class PostUploadServiceTest {
         assertThatThrownBy(() ->
                 postUploadService.uploadPost(userSeq, postUploadRequest)
         )
-                .isInstanceOf(CustomException.class)
+                .isInstanceOf(PostException.class)
                 .hasMessage(FAILED_TO_SAVE_POST.getMessage());
 
         verify(bulkInsertRepository).saveAll(anyList(), anyString(), any(BiConsumer.class));

--- a/src/test/java/com/backend/immilog/post/presentation/controller/PostControllerTest.java
+++ b/src/test/java/com/backend/immilog/post/presentation/controller/PostControllerTest.java
@@ -1,6 +1,5 @@
 package com.backend.immilog.post.presentation.controller;
 
-import com.backend.immilog.global.enums.Countries;
 import com.backend.immilog.global.presentation.response.ApiResponse;
 import com.backend.immilog.post.model.dtos.PostDTO;
 import com.backend.immilog.post.model.enums.Categories;
@@ -13,6 +12,7 @@ import com.backend.immilog.post.presentation.request.PostUpdateRequest;
 import com.backend.immilog.post.presentation.request.PostUploadRequest;
 import com.backend.immilog.user.model.embeddables.Location;
 import com.backend.immilog.user.model.entities.User;
+import com.backend.immilog.user.model.enums.UserCountry;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -64,7 +64,7 @@ class PostControllerTest {
                 .isPublic(true)
                 .build();
         Location location = Location.builder()
-                .country(Countries.SOUTH_KOREA)
+                .country(UserCountry.SOUTH_KOREA)
                 .region("region")
                 .build();
         User user = User.builder()

--- a/src/test/java/com/backend/immilog/user/application/LocationServiceTest.java
+++ b/src/test/java/com/backend/immilog/user/application/LocationServiceTest.java
@@ -14,7 +14,7 @@ import org.springframework.web.client.RestTemplate;
 
 import java.util.concurrent.CompletableFuture;
 
-import static com.backend.immilog.global.enums.Countries.SOUTH_KOREA;
+import static com.backend.immilog.global.enums.GlobalCountry.SOUTH_KOREA;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.test.web.client.response.MockRestResponseCreators.withServerError;
 import static org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess;

--- a/src/test/java/com/backend/immilog/user/application/UserInformationServiceTest.java
+++ b/src/test/java/com/backend/immilog/user/application/UserInformationServiceTest.java
@@ -1,9 +1,9 @@
 package com.backend.immilog.user.application;
 
 import com.backend.immilog.global.application.ImageService;
-import com.backend.immilog.global.exception.CustomException;
 import com.backend.immilog.user.application.command.UserPasswordChangeCommand;
 import com.backend.immilog.user.application.services.UserInformationServiceImpl;
+import com.backend.immilog.user.exception.UserException;
 import com.backend.immilog.user.model.embeddables.Location;
 import com.backend.immilog.user.model.entities.User;
 import com.backend.immilog.user.model.enums.UserStatus;
@@ -22,11 +22,11 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 
-import static com.backend.immilog.global.enums.Countries.*;
 import static com.backend.immilog.global.enums.UserRole.ROLE_ADMIN;
 import static com.backend.immilog.global.enums.UserRole.ROLE_USER;
 import static com.backend.immilog.user.exception.UserErrorCode.NOT_AN_ADMIN_USER;
 import static com.backend.immilog.user.exception.UserErrorCode.PASSWORD_NOT_MATCH;
+import static com.backend.immilog.user.model.enums.UserCountry.*;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.when;
@@ -161,7 +161,7 @@ class UserInformationServiceTest {
 
         // when & then
         assertThatThrownBy(() -> userInformationService.changePassword(userSeq, param.toCommand()))
-                .isInstanceOf(CustomException.class)
+                .isInstanceOf(UserException.class)
                 .hasMessage(PASSWORD_NOT_MATCH.getMessage());
     }
 
@@ -231,7 +231,7 @@ class UserInformationServiceTest {
                 adminSeq,
                 userStatus
         ))
-                .isInstanceOf(CustomException.class)
+                .isInstanceOf(UserException.class)
                 .hasMessage(NOT_AN_ADMIN_USER.getMessage());
     }
 }

--- a/src/test/java/com/backend/immilog/user/application/UserReportServiceTest.java
+++ b/src/test/java/com/backend/immilog/user/application/UserReportServiceTest.java
@@ -1,9 +1,9 @@
 package com.backend.immilog.user.application;
 
 import com.backend.immilog.global.application.RedisDistributedLock;
-import com.backend.immilog.global.exception.CustomException;
 import com.backend.immilog.user.application.services.UserReportServiceImpl;
 import com.backend.immilog.user.enums.ReportReason;
+import com.backend.immilog.user.exception.UserException;
 import com.backend.immilog.user.model.embeddables.Location;
 import com.backend.immilog.user.model.embeddables.ReportInfo;
 import com.backend.immilog.user.model.entities.Report;
@@ -23,11 +23,11 @@ import java.sql.Date;
 import java.time.LocalDateTime;
 import java.util.Optional;
 
-import static com.backend.immilog.global.enums.Countries.MALAYSIA;
-import static com.backend.immilog.global.enums.Countries.SOUTH_KOREA;
 import static com.backend.immilog.global.enums.UserRole.ROLE_USER;
 import static com.backend.immilog.user.exception.UserErrorCode.ALREADY_REPORTED;
 import static com.backend.immilog.user.exception.UserErrorCode.CANNOT_REPORT_MYSELF;
+import static com.backend.immilog.user.model.enums.UserCountry.MALAYSIA;
+import static com.backend.immilog.user.model.enums.UserCountry.SOUTH_KOREA;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.*;
 
@@ -115,7 +115,7 @@ class UserReportServiceTest {
                 reporterUserSeq,
                 reportUserRequest.toCommand()
         ))
-                .isInstanceOf(CustomException.class)
+                .isInstanceOf(UserException.class)
                 .hasMessage(CANNOT_REPORT_MYSELF.getMessage());
     }
 
@@ -135,7 +135,7 @@ class UserReportServiceTest {
                 reporterUserSeq,
                 reportUserRequest.toCommand()
         ))
-                .isInstanceOf(CustomException.class)
+                .isInstanceOf(UserException.class)
                 .hasMessage(ALREADY_REPORTED.getMessage());
     }
 }

--- a/src/test/java/com/backend/immilog/user/application/UserSignInServiceTest.java
+++ b/src/test/java/com/backend/immilog/user/application/UserSignInServiceTest.java
@@ -1,11 +1,11 @@
 package com.backend.immilog.user.application;
 
 import com.backend.immilog.global.application.RedisService;
-import com.backend.immilog.global.enums.Countries;
+import com.backend.immilog.global.enums.GlobalCountry;
 import com.backend.immilog.global.enums.UserRole;
-import com.backend.immilog.global.exception.CustomException;
 import com.backend.immilog.global.security.TokenProvider;
 import com.backend.immilog.user.application.services.UserSignInServiceImpl;
+import com.backend.immilog.user.exception.UserException;
 import com.backend.immilog.user.model.dtos.UserSignInDTO;
 import com.backend.immilog.user.model.embeddables.Location;
 import com.backend.immilog.user.model.entities.User;
@@ -24,10 +24,10 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 
-import static com.backend.immilog.global.enums.Countries.MALAYSIA;
-import static com.backend.immilog.global.enums.Countries.SOUTH_KOREA;
 import static com.backend.immilog.global.enums.UserRole.ROLE_USER;
 import static com.backend.immilog.user.exception.UserErrorCode.USER_NOT_FOUND;
+import static com.backend.immilog.user.model.enums.UserCountry.MALAYSIA;
+import static com.backend.immilog.user.model.enums.UserCountry.SOUTH_KOREA;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -72,7 +72,7 @@ class UserSignInServiceTest {
                 .build();
 
         Location location = Location.builder()
-                .country(Countries.SOUTH_KOREA)
+                .country(SOUTH_KOREA)
                 .region("서울")
                 .build();
 
@@ -93,7 +93,7 @@ class UserSignInServiceTest {
                 anyLong(),
                 anyString(),
                 any(UserRole.class),
-                any(Countries.class)
+                any(GlobalCountry.class)
         )).thenReturn("accessToken");
         when(tokenProvider.issueRefreshToken())
                 .thenReturn("refreshToken");
@@ -111,7 +111,7 @@ class UserSignInServiceTest {
                 anyLong(),
                 anyString(),
                 any(UserRole.class),
-                any(Countries.class)
+                any(GlobalCountry.class)
         );
         verify(tokenProvider, times(1)).issueRefreshToken();
     }
@@ -128,7 +128,7 @@ class UserSignInServiceTest {
                 .build();
 
         Location location = Location.builder()
-                .country(Countries.SOUTH_KOREA)
+                .country(SOUTH_KOREA)
                 .region("서울")
                 .build();
 
@@ -145,7 +145,7 @@ class UserSignInServiceTest {
         assertThatThrownBy(() -> {
             userSignInService.signIn(userSignInRequest.toCommand(), country);
         })
-                .isInstanceOf(CustomException.class)
+                .isInstanceOf(UserException.class)
                 .hasMessage(USER_NOT_FOUND.getMessage());
     }
 
@@ -172,7 +172,7 @@ class UserSignInServiceTest {
                 anyLong(),
                 anyString(),
                 any(UserRole.class),
-                any(Countries.class)
+                any(GlobalCountry.class)
         )).thenReturn("accessToken");
         when(tokenProvider.issueRefreshToken()).thenReturn("refreshToken");
 
@@ -208,7 +208,7 @@ class UserSignInServiceTest {
                 anyLong(),
                 anyString(),
                 any(UserRole.class),
-                any(Countries.class)
+                any(GlobalCountry.class)
         )).thenReturn("accessToken");
         when(tokenProvider.issueRefreshToken()).thenReturn("refreshToken");
 

--- a/src/test/java/com/backend/immilog/user/application/UserSignUpServiceTest.java
+++ b/src/test/java/com/backend/immilog/user/application/UserSignUpServiceTest.java
@@ -1,7 +1,7 @@
 package com.backend.immilog.user.application;
 
-import com.backend.immilog.global.exception.CustomException;
 import com.backend.immilog.user.application.services.UserSignUpServiceImpl;
+import com.backend.immilog.user.exception.UserException;
 import com.backend.immilog.user.model.entities.User;
 import com.backend.immilog.user.model.repositories.UserRepository;
 import com.backend.immilog.user.model.services.UserSignUpService;
@@ -16,9 +16,9 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 
 import java.util.Optional;
 
-import static com.backend.immilog.user.model.enums.UserStatus.*;
 import static com.backend.immilog.user.exception.UserErrorCode.EXISTING_USER;
 import static com.backend.immilog.user.exception.UserErrorCode.USER_NOT_FOUND;
+import static com.backend.immilog.user.model.enums.UserStatus.*;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.*;
@@ -82,7 +82,7 @@ class UserSignUpServiceTest {
                 .thenReturn(Optional.of(new User()));
 
         assertThatThrownBy(() -> userSignUpService.signUp(param.toCommand()))
-                .isInstanceOf(CustomException.class)
+                .isInstanceOf(UserException.class)
                 .hasMessage(EXISTING_USER.getMessage());
     }
 
@@ -132,7 +132,7 @@ class UserSignUpServiceTest {
         when(userRepository.findById(userSeq)).thenReturn(Optional.empty());
         // when & then
         assertThatThrownBy(() -> userSignUpService.verifyEmail(userSeq))
-                .isInstanceOf(CustomException.class)
+                .isInstanceOf(UserException.class)
                 .hasMessage(USER_NOT_FOUND.getMessage());
     }
 

--- a/src/test/java/com/backend/immilog/user/presentation/controller/LocationControllerTest.java
+++ b/src/test/java/com/backend/immilog/user/presentation/controller/LocationControllerTest.java
@@ -1,6 +1,6 @@
 package com.backend.immilog.user.presentation.controller;
 
-import com.backend.immilog.global.enums.Countries;
+import com.backend.immilog.global.enums.GlobalCountry;
 import com.backend.immilog.global.presentation.response.ApiResponse;
 import com.backend.immilog.user.model.services.LocationService;
 import com.backend.immilog.user.presentation.response.LocationResponse;
@@ -15,7 +15,7 @@ import org.springframework.http.ResponseEntity;
 import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
 
-import static com.backend.immilog.global.enums.Countries.SOUTH_KOREA;
+import static com.backend.immilog.global.enums.GlobalCountry.SOUTH_KOREA;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.when;
 import static org.springframework.http.HttpStatus.OK;
@@ -57,7 +57,7 @@ class LocationControllerTest {
         LocationResponse locationResponse =
                 (LocationResponse) ((ApiResponse) Objects.requireNonNull(response.getBody())).data();
         assertThat(locationResponse).isNotNull();
-        assertThat(Countries.getCountryByKoreanName(country).getCountryName())
+        assertThat(GlobalCountry.getCountryByKoreanName(country).getCountryName())
                 .isEqualTo(locationResponse.country());
         assertThat(SOUTH_KOREA.toString()).isEqualTo(locationResponse.country());
     }

--- a/src/test/java/com/backend/immilog/user/presentation/controller/UserControllerTest.java
+++ b/src/test/java/com/backend/immilog/user/presentation/controller/UserControllerTest.java
@@ -19,8 +19,8 @@ import javax.servlet.http.HttpServletRequest;
 import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
 
-import static com.backend.immilog.global.enums.Countries.INDONESIA;
-import static com.backend.immilog.global.enums.Countries.JAPAN;
+import static com.backend.immilog.user.model.enums.UserCountry.INDONESIA;
+import static com.backend.immilog.user.model.enums.UserCountry.JAPAN;
 import static com.backend.immilog.user.enums.ReportReason.FRAUD;
 import static com.backend.immilog.user.model.enums.UserStatus.ACTIVE;
 import static org.assertj.core.api.Assertions.assertThat;


### PR DESCRIPTION
* refactor (global) : Exception 및 Country enum 도메인 별로 분리

* refactor (notice) : Exception 및 Country enum 도메인 별로 분리

* refactor (post) : Exception 및 Country enum 도메인 별로 분리

* refactor (user) : Exception 및 Country enum 도메인 별로 분리

* test (global) : Exception 및 Country enum 도메인 별 분리로 인한 테스트 코드 수정

* test (notice) : Exception 및 Country enum 도메인 별 분리로 인한 테스트 코드 수정

* test (post) : Exception 및 Country enum 도메인 별 분리로 인한 테스트 코드 수정

* test (user) : Exception 및 Country enum 도메인 별 분리로 인한 테스트 코드 수정

### 작업 내용
- Exception 및 Country enum 도메인 별로 분리하여 도메인 결합도 최소화
- 테스트 코드 수정

### 특이 사항
- 유지보수 성 증대를 위한 리팩토링 
