### PR TITLE
refactor (global) : 계층별 DTO를 분리하여 유지보수성과 명확성 개선  (#252)

### DIFF
--- a/src/main/java/com/backend/immilog/global/presentation/controller/ImageController.java
+++ b/src/main/java/com/backend/immilog/global/presentation/controller/ImageController.java
@@ -2,7 +2,7 @@ package com.backend.immilog.global.presentation.controller;
 
 import com.backend.immilog.global.application.ImageService;
 import com.backend.immilog.global.presentation.request.ImageRequest;
-import com.backend.immilog.global.presentation.response.ApiResponse;
+import com.backend.immilog.global.presentation.response.GlobalApiResponse;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import lombok.RequiredArgsConstructor;
@@ -25,7 +25,7 @@ public class ImageController {
 
     @PostMapping
     @ApiOperation(value = "이미지 업로드", notes = "이미지를 업로드합니다.")
-    public ResponseEntity<ApiResponse> uploadImage(
+    public ResponseEntity<GlobalApiResponse> uploadImage(
             List<MultipartFile> multipartFile,
             @RequestParam String imagePath
     ) {
@@ -33,12 +33,12 @@ public class ImageController {
 
         return ResponseEntity
                 .status(OK)
-                .body(ApiResponse.of(data));
+                .body(GlobalApiResponse.of(data));
     }
 
     @DeleteMapping
     @ApiOperation(value = "이미지 삭제", notes = "이미지를 삭제합니다.")
-    public ResponseEntity<ApiResponse> deleteImage(
+    public ResponseEntity<GlobalApiResponse> deleteImage(
             ImageRequest imageRequest
     ) {
         imageService.deleteFile(imageRequest.imagePath());

--- a/src/main/java/com/backend/immilog/global/presentation/response/GlobalApiResponse.java
+++ b/src/main/java/com/backend/immilog/global/presentation/response/GlobalApiResponse.java
@@ -6,16 +6,14 @@ import org.springframework.http.HttpStatus;
 import java.util.List;
 
 @Builder
-public record ApiResponse(
+public record GlobalApiResponse(
         Integer status,
         String message,
         Object data,
         List<Object> list
 ) {
-    public static ApiResponse of(
-            Object data
-    ) {
-        return ApiResponse.builder()
+    public static GlobalApiResponse of(Object data) {
+        return GlobalApiResponse.builder()
                 .status(HttpStatus.OK.value())
                 .message(null)
                 .data(data)

--- a/src/main/java/com/backend/immilog/notice/application/command/NoticeUploadCommand.java
+++ b/src/main/java/com/backend/immilog/notice/application/command/NoticeUploadCommand.java
@@ -1,0 +1,18 @@
+package com.backend.immilog.notice.application.command;
+
+import com.backend.immilog.notice.model.enums.NoticeCountry;
+import com.backend.immilog.notice.model.enums.NoticeType;
+import io.swagger.annotations.ApiModel;
+import lombok.Builder;
+
+import java.util.List;
+
+@Builder
+@ApiModel(value = "NoticeRegisterCommand", description = "공지사항 생성 요청 서비스 DTO")
+public record NoticeUploadCommand(
+        String title,
+        String content,
+        NoticeType type,
+        List<NoticeCountry> targetCountries
+) {
+}

--- a/src/main/java/com/backend/immilog/notice/application/dtos/NoticeDTO.java
+++ b/src/main/java/com/backend/immilog/notice/application/dtos/NoticeDTO.java
@@ -1,4 +1,4 @@
-package com.backend.immilog.notice.model.dtos;
+package com.backend.immilog.notice.application.dtos;
 
 import com.backend.immilog.notice.model.entities.Notice;
 import com.backend.immilog.notice.model.enums.NoticeCountry;

--- a/src/main/java/com/backend/immilog/notice/application/services/NoticeInquiryService.java
+++ b/src/main/java/com/backend/immilog/notice/application/services/NoticeInquiryService.java
@@ -1,7 +1,7 @@
-package com.backend.immilog.notice.application;
+package com.backend.immilog.notice.application.services;
 
 import com.backend.immilog.notice.exception.NoticeException;
-import com.backend.immilog.notice.model.dtos.NoticeDTO;
+import com.backend.immilog.notice.application.dtos.NoticeDTO;
 import com.backend.immilog.notice.model.repositories.NoticeRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;

--- a/src/main/java/com/backend/immilog/notice/application/services/NoticeRegisterService.java
+++ b/src/main/java/com/backend/immilog/notice/application/services/NoticeRegisterService.java
@@ -1,10 +1,10 @@
-package com.backend.immilog.notice.application;
+package com.backend.immilog.notice.application.services;
 
 import com.backend.immilog.global.enums.UserRole;
+import com.backend.immilog.notice.application.command.NoticeUploadCommand;
 import com.backend.immilog.notice.exception.NoticeException;
 import com.backend.immilog.notice.model.entities.Notice;
 import com.backend.immilog.notice.model.repositories.NoticeRepository;
-import com.backend.immilog.notice.presentation.request.NoticeRegisterRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -23,10 +23,10 @@ public class NoticeRegisterService {
     public void registerNotice(
             Long userSeq,
             UserRole userRole,
-            NoticeRegisterRequest request
+            NoticeUploadCommand command
     ) {
         validateAdminUser(userRole);
-        noticeRepository.save(Notice.of(userSeq, request));
+        noticeRepository.save(Notice.of(userSeq, command));
     }
 
     private static void validateAdminUser(

--- a/src/main/java/com/backend/immilog/notice/infrastructure/NoticeRepositoryImpl.java
+++ b/src/main/java/com/backend/immilog/notice/infrastructure/NoticeRepositoryImpl.java
@@ -1,6 +1,6 @@
 package com.backend.immilog.notice.infrastructure;
 
-import com.backend.immilog.notice.model.dtos.NoticeDTO;
+import com.backend.immilog.notice.application.dtos.NoticeDTO;
 import com.backend.immilog.notice.model.entities.QNotice;
 import com.backend.immilog.notice.model.repositories.NoticeRepositoryCustom;
 import com.backend.immilog.user.model.entities.QUser;

--- a/src/main/java/com/backend/immilog/notice/model/entities/Notice.java
+++ b/src/main/java/com/backend/immilog/notice/model/entities/Notice.java
@@ -1,10 +1,10 @@
 package com.backend.immilog.notice.model.entities;
 
 import com.backend.immilog.global.model.BaseDateEntity;
+import com.backend.immilog.notice.application.command.NoticeUploadCommand;
 import com.backend.immilog.notice.model.enums.NoticeCountry;
 import com.backend.immilog.notice.model.enums.NoticeStatus;
 import com.backend.immilog.notice.model.enums.NoticeType;
-import com.backend.immilog.notice.presentation.request.NoticeRegisterRequest;
 import lombok.*;
 import org.hibernate.annotations.Cascade;
 import org.hibernate.annotations.DynamicUpdate;
@@ -50,14 +50,14 @@ public class Notice extends BaseDateEntity {
 
     public static Notice of(
             Long userSeq,
-            NoticeRegisterRequest request
+            NoticeUploadCommand command
     ) {
         return Notice.builder()
-                .title(request.getTitle())
+                .title(command.title())
                 .userSeq(userSeq)
-                .content(request.getContent())
-                .type(request.getType())
-                .targetCountries(request.getTargetCountries())
+                .content(command.content())
+                .type(command.type())
+                .targetCountries(command.targetCountries())
                 .status(NORMAL)
                 .build();
     }

--- a/src/main/java/com/backend/immilog/notice/model/repositories/NoticeRepositoryCustom.java
+++ b/src/main/java/com/backend/immilog/notice/model/repositories/NoticeRepositoryCustom.java
@@ -1,6 +1,6 @@
 package com.backend.immilog.notice.model.repositories;
 
-import com.backend.immilog.notice.model.dtos.NoticeDTO;
+import com.backend.immilog.notice.application.dtos.NoticeDTO;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 

--- a/src/main/java/com/backend/immilog/notice/presentation/controller/NoticeController.java
+++ b/src/main/java/com/backend/immilog/notice/presentation/controller/NoticeController.java
@@ -1,12 +1,12 @@
 package com.backend.immilog.notice.presentation.controller;
 
 import com.backend.immilog.global.enums.UserRole;
-import com.backend.immilog.global.presentation.response.ApiResponse;
 import com.backend.immilog.global.security.ExtractUserId;
-import com.backend.immilog.notice.application.NoticeInquiryService;
-import com.backend.immilog.notice.application.NoticeRegisterService;
-import com.backend.immilog.notice.model.dtos.NoticeDTO;
+import com.backend.immilog.notice.application.dtos.NoticeDTO;
+import com.backend.immilog.notice.application.services.NoticeInquiryService;
+import com.backend.immilog.notice.application.services.NoticeRegisterService;
 import com.backend.immilog.notice.presentation.request.NoticeRegisterRequest;
+import com.backend.immilog.notice.presentation.response.NoticeApiResponse;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import lombok.RequiredArgsConstructor;
@@ -30,37 +30,37 @@ public class NoticeController {
     @PostMapping
     @ExtractUserId
     @ApiOperation(value = "공지사항 등록", notes = "공지사항을 등록합니다.")
-    public ResponseEntity<ApiResponse> registerNotice(
+    public ResponseEntity<NoticeApiResponse> registerNotice(
             @RequestBody NoticeRegisterRequest noticeRegisterRequest,
             HttpServletRequest request
     ) {
         Long userSeq = (Long) request.getAttribute("userSeq");
         UserRole userRole = (UserRole) request.getAttribute("userRole");
-        noticeRegisterService.registerNotice(userSeq, userRole, noticeRegisterRequest);
+        noticeRegisterService.registerNotice(userSeq, userRole, noticeRegisterRequest.toCommand());
         return ResponseEntity
                 .status(CREATED)
-                .body(ApiResponse.of(true));
+                .body(NoticeApiResponse.of(true));
     }
 
     @GetMapping
     @ExtractUserId
     @ApiOperation(value = "공지사항 조회", notes = "공지사항을 조회합니다.")
-    public ResponseEntity<ApiResponse> getNotices(
+    public ResponseEntity<NoticeApiResponse> getNotices(
             @RequestParam Integer page,
             HttpServletRequest request
     ) {
         Long userSeq = (Long) request.getAttribute("userSeq");
         Page<NoticeDTO> notices = noticeInquiryService.getNotices(userSeq, page);
-        return ResponseEntity.status(OK).body(ApiResponse.of(notices));
+        return ResponseEntity.status(OK).body(NoticeApiResponse.of(notices));
     }
 
     @GetMapping("/{noticeSeq}")
     @ApiOperation(value = "공지사항 조회", notes = "공지사항을 조회합니다.")
-    public ResponseEntity<ApiResponse> getNoticeDetail(
+    public ResponseEntity<NoticeApiResponse> getNoticeDetail(
             @PathVariable Long noticeSeq
     ) {
         NoticeDTO notices = noticeInquiryService.getNoticeDetail(noticeSeq);
-        return ResponseEntity.status(OK).body(ApiResponse.of(notices));
+        return ResponseEntity.status(OK).body(NoticeApiResponse.of(notices));
     }
 
 }

--- a/src/main/java/com/backend/immilog/notice/presentation/request/NoticeRegisterRequest.java
+++ b/src/main/java/com/backend/immilog/notice/presentation/request/NoticeRegisterRequest.java
@@ -1,21 +1,27 @@
 package com.backend.immilog.notice.presentation.request;
 
+import com.backend.immilog.notice.application.command.NoticeUploadCommand;
 import com.backend.immilog.notice.model.enums.NoticeCountry;
 import com.backend.immilog.notice.model.enums.NoticeType;
-import lombok.AllArgsConstructor;
+import io.swagger.annotations.ApiModel;
 import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
 
 import java.util.List;
 
-@Getter
-@AllArgsConstructor
-@NoArgsConstructor
 @Builder
-public class NoticeRegisterRequest {
-    private String title;
-    private String content;
-    private NoticeType type;
-    private List<NoticeCountry> targetCountries;
+@ApiModel(value = "NoticeRegisterRequest", description = "공지사항 생성 요청 서비스 DTO")
+public record NoticeRegisterRequest(
+        String title,
+        String content,
+        NoticeType type,
+        List<NoticeCountry> targetCountries
+) {
+    public NoticeUploadCommand toCommand() {
+        return NoticeUploadCommand.builder()
+                .title(title)
+                .content(content)
+                .type(type)
+                .targetCountries(targetCountries)
+                .build();
+    }
 }

--- a/src/main/java/com/backend/immilog/notice/presentation/response/NoticeApiResponse.java
+++ b/src/main/java/com/backend/immilog/notice/presentation/response/NoticeApiResponse.java
@@ -1,0 +1,23 @@
+package com.backend.immilog.notice.presentation.response;
+
+import lombok.Builder;
+import org.springframework.http.HttpStatus;
+
+import java.util.List;
+
+@Builder
+public record NoticeApiResponse(
+        Integer status,
+        String message,
+        Object data,
+        List<Object> list
+) {
+    public static NoticeApiResponse of(Object data) {
+        return NoticeApiResponse.builder()
+                .status(HttpStatus.OK.value())
+                .message(null)
+                .data(data)
+                .list(null)
+                .build();
+    }
+}

--- a/src/main/java/com/backend/immilog/post/application/command/PostUpdateCommand.java
+++ b/src/main/java/com/backend/immilog/post/application/command/PostUpdateCommand.java
@@ -1,0 +1,21 @@
+package com.backend.immilog.post.application.command;
+
+import io.swagger.annotations.ApiModel;
+import lombok.Builder;
+
+import java.util.List;
+
+@Builder
+@ApiModel(value = "PostUpdateCommand", description = "게시물 수정 요청 Service DTO")
+public record PostUpdateCommand(
+        String title,
+        String content,
+        List<String> deleteTags,
+        List<String> addTags,
+        List<String> deleteAttachments,
+        List<String> addAttachments,
+        Boolean isPublic
+) {
+}
+
+

--- a/src/main/java/com/backend/immilog/post/application/command/PostUploadCommand.java
+++ b/src/main/java/com/backend/immilog/post/application/command/PostUploadCommand.java
@@ -1,6 +1,5 @@
-package com.backend.immilog.post.presentation.request;
+package com.backend.immilog.post.application.command;
 
-import com.backend.immilog.post.application.command.PostUploadCommand;
 import com.backend.immilog.post.model.enums.Categories;
 import io.swagger.annotations.ApiModel;
 import lombok.Builder;
@@ -10,8 +9,8 @@ import javax.validation.constraints.NotNull;
 import java.util.List;
 
 @Builder
-@ApiModel(value = "PostUploadRequest", description = "게시물 생성 요청 DTO")
-public record PostUploadRequest(
+@ApiModel(value = "PostUploadCommand", description = "게시물 생성 요청 서비스 DTO")
+public record PostUploadCommand(
         @NotBlank(message = "제목을 입력해주세요.") String title,
         @NotBlank(message = "내용을 입력해주세요.") String content,
         List<String> tags,
@@ -19,14 +18,4 @@ public record PostUploadRequest(
         @NotNull(message = "전체공개 여부를 입력해주세요.") Boolean isPublic,
         @NotNull(message = "카테고리를 입력해주세요.") Categories category
 ) {
-    public PostUploadCommand toCommand() {
-        return PostUploadCommand.builder()
-                .title(title)
-                .content(content)
-                .tags(tags)
-                .attachments(attachments)
-                .isPublic(isPublic)
-                .category(category)
-                .build();
-    }
 }

--- a/src/main/java/com/backend/immilog/post/application/dtos/CommentDTO.java
+++ b/src/main/java/com/backend/immilog/post/application/dtos/CommentDTO.java
@@ -1,8 +1,8 @@
-package com.backend.immilog.post.model.dtos;
+package com.backend.immilog.post.application.dtos;
 
 import com.backend.immilog.post.model.entities.Comment;
 import com.backend.immilog.post.model.enums.PostStatus;
-import com.backend.immilog.user.model.dtos.UserDTO;
+import com.backend.immilog.user.application.dto.UserDataDTO;
 import com.backend.immilog.user.model.entities.User;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -20,7 +20,7 @@ import java.util.Objects;
 @Builder
 public class CommentDTO {
     private Long seq;
-    private UserDTO user;
+    private UserDataDTO user;
     private String content;
     private List<CommentDTO> replies;
     private int upVotes;
@@ -39,7 +39,7 @@ public class CommentDTO {
         List<CommentDTO> replyList = combineReplies(replies, replyUsers);
 
         this.seq = comment.getSeq();
-        this.user = UserDTO.from(user);
+        this.user = UserDataDTO.from(user);
         this.content = comment.getContent();
         this.replies = replyList;
         this.upVotes = comment.getLikeCount();
@@ -55,7 +55,7 @@ public class CommentDTO {
     ) {
         return CommentDTO.builder()
                 .seq(comment.getSeq())
-                .user(UserDTO.from(user))
+                .user(UserDataDTO.from(user))
                 .content(comment.getContent())
                 .replies(new ArrayList<>())
                 .upVotes(comment.getLikeCount())

--- a/src/main/java/com/backend/immilog/post/application/dtos/PostDTO.java
+++ b/src/main/java/com/backend/immilog/post/application/dtos/PostDTO.java
@@ -1,4 +1,4 @@
-package com.backend.immilog.post.model.dtos;
+package com.backend.immilog.post.application.dtos;
 
 import com.backend.immilog.post.model.embeddables.PostMetaData;
 import com.backend.immilog.post.model.embeddables.PostUserData;

--- a/src/main/java/com/backend/immilog/post/application/services/CommentUploadService.java
+++ b/src/main/java/com/backend/immilog/post/application/services/CommentUploadService.java
@@ -26,19 +26,14 @@ public class CommentUploadService {
             Long userId,
             Long postSeq,
             String referenceType,
-            CommentUploadRequest commentUploadRequest
+            String content
     ) {
         Post post = getPost(postSeq);
         post.setCommentCount(post.getCommentCount() + 1);
 
         ReferenceType reference = ReferenceType.getByString(referenceType);
 
-        Comment comment = Comment.of(
-                userId,
-                postSeq,
-                commentUploadRequest.content(),
-                reference
-        );
+        Comment comment = Comment.of(userId, postSeq, content, reference);
 
         commentRepository.save(comment);
     }

--- a/src/main/java/com/backend/immilog/post/application/services/PostInquiryService.java
+++ b/src/main/java/com/backend/immilog/post/application/services/PostInquiryService.java
@@ -1,8 +1,8 @@
 package com.backend.immilog.post.application.services;
 
 import com.backend.immilog.post.exception.PostException;
-import com.backend.immilog.post.model.dtos.CommentDTO;
-import com.backend.immilog.post.model.dtos.PostDTO;
+import com.backend.immilog.post.application.dtos.CommentDTO;
+import com.backend.immilog.post.application.dtos.PostDTO;
 import com.backend.immilog.post.model.enums.Categories;
 import com.backend.immilog.post.model.enums.Countries;
 import com.backend.immilog.post.model.enums.SortingMethods;

--- a/src/main/java/com/backend/immilog/post/application/services/PostUploadService.java
+++ b/src/main/java/com/backend/immilog/post/application/services/PostUploadService.java
@@ -1,11 +1,11 @@
 package com.backend.immilog.post.application.services;
 
+import com.backend.immilog.post.application.command.PostUploadCommand;
 import com.backend.immilog.post.exception.PostException;
 import com.backend.immilog.post.model.entities.Post;
 import com.backend.immilog.post.model.entities.PostResource;
 import com.backend.immilog.post.model.repositories.BulkInsertRepository;
 import com.backend.immilog.post.model.repositories.PostRepository;
-import com.backend.immilog.post.presentation.request.PostUploadRequest;
 import com.backend.immilog.user.model.entities.User;
 import com.backend.immilog.user.model.repositories.UserRepository;
 import lombok.RequiredArgsConstructor;
@@ -35,33 +35,33 @@ public class PostUploadService {
     @Transactional
     public void uploadPost(
             Long userSeq,
-            PostUploadRequest postUploadRequest
+            PostUploadCommand postUploadCommand
     ) {
         User user = getUser(userSeq);
         Post post = postRepository.save(
-                createPostEntity(userSeq, postUploadRequest, user)
+                createPostEntity(userSeq, postUploadCommand, user)
         );
         Long postSeq = post.getSeq();
-        insertAllPostResources(postUploadRequest, postSeq);
+        insertAllPostResources(postUploadCommand, postSeq);
     }
 
     private static Post createPostEntity(
             Long userSeq,
-            PostUploadRequest postUploadRequest,
+            PostUploadCommand postUploadCommand,
             User user
     ) {
         return Post.of(
-                postUploadRequest,
+                postUploadCommand,
                 user
         );
     }
 
     private void insertAllPostResources(
-            PostUploadRequest postUploadRequest,
+            PostUploadCommand postUploadCommand,
             Long postSeq
     ) {
         List<PostResource> postResourceList = getPostResourceList(
-                postUploadRequest,
+                postUploadCommand,
                 postSeq
         );
         bulkInsertRepository.saveAll(
@@ -89,23 +89,23 @@ public class PostUploadService {
     }
 
     private List<PostResource> getPostResourceList(
-            PostUploadRequest postUploadRequest,
+            PostUploadCommand postUploadCommand,
             Long postSeq
     ) {
         List<PostResource> postResources = new ArrayList<>();
-        postResources.addAll(getTagEntities(postUploadRequest, postSeq));
-        postResources.addAll(getAttachmentEntities(postUploadRequest, postSeq));
+        postResources.addAll(getTagEntities(postUploadCommand, postSeq));
+        postResources.addAll(getAttachmentEntities(postUploadCommand, postSeq));
         return Collections.unmodifiableList(postResources);
     }
 
     private List<PostResource> getTagEntities(
-            PostUploadRequest postUploadRequest,
+            PostUploadCommand postUploadCommand,
             Long postSeq
     ) {
-        if (postUploadRequest.tags() == null) {
+        if (postUploadCommand.tags() == null) {
             return List.of();
         }
-        return postUploadRequest
+        return postUploadCommand
                 .tags()
                 .stream()
                 .map(tag -> PostResource.of(POST, TAG, tag, postSeq))
@@ -113,13 +113,13 @@ public class PostUploadService {
     }
 
     private List<PostResource> getAttachmentEntities(
-            PostUploadRequest postUploadRequest,
+            PostUploadCommand postUploadCommand,
             Long postSeq
     ) {
-        if (postUploadRequest.attachments() == null) {
+        if (postUploadCommand.attachments() == null) {
             return List.of();
         }
-        return postUploadRequest
+        return postUploadCommand
                 .attachments()
                 .stream()
                 .map(url -> PostResource.of(POST, ATTACHMENT, url, postSeq))

--- a/src/main/java/com/backend/immilog/post/infrastructure/CommentRepositoryImpl.java
+++ b/src/main/java/com/backend/immilog/post/infrastructure/CommentRepositoryImpl.java
@@ -1,6 +1,6 @@
 package com.backend.immilog.post.infrastructure;
 
-import com.backend.immilog.post.model.dtos.CommentDTO;
+import com.backend.immilog.post.application.dtos.CommentDTO;
 import com.backend.immilog.post.model.entities.QComment;
 import com.backend.immilog.post.model.repositories.CommentRepositoryCustom;
 import com.backend.immilog.user.model.entities.QUser;

--- a/src/main/java/com/backend/immilog/post/infrastructure/PostRepositoryImpl.java
+++ b/src/main/java/com/backend/immilog/post/infrastructure/PostRepositoryImpl.java
@@ -1,6 +1,6 @@
 package com.backend.immilog.post.infrastructure;
 
-import com.backend.immilog.post.model.dtos.PostDTO;
+import com.backend.immilog.post.application.dtos.PostDTO;
 import com.backend.immilog.post.model.entities.QInteractionUser;
 import com.backend.immilog.post.model.entities.QPost;
 import com.backend.immilog.post.model.entities.QPostResource;

--- a/src/main/java/com/backend/immilog/post/model/embeddables/PostMetaData.java
+++ b/src/main/java/com/backend/immilog/post/model/embeddables/PostMetaData.java
@@ -1,8 +1,8 @@
 package com.backend.immilog.post.model.embeddables;
 
+import com.backend.immilog.post.application.command.PostUploadCommand;
 import com.backend.immilog.post.model.enums.Countries;
 import com.backend.immilog.post.model.enums.PostStatus;
-import com.backend.immilog.post.presentation.request.PostUploadRequest;
 import lombok.*;
 
 import javax.persistence.Embeddable;
@@ -38,13 +38,13 @@ public class PostMetaData {
     private Countries country;
 
     public static PostMetaData of(
-            PostUploadRequest postUploadRequest,
+            PostUploadCommand postUploadCommand,
             Countries country,
             String region
     ) {
         return PostMetaData.builder()
-                .title(postUploadRequest.title())
-                .content(postUploadRequest.content())
+                .title(postUploadCommand.title())
+                .content(postUploadCommand.content())
                 .viewCount(0L)
                 .likeCount(0L)
                 .status(PostStatus.NORMAL)

--- a/src/main/java/com/backend/immilog/post/model/entities/Post.java
+++ b/src/main/java/com/backend/immilog/post/model/entities/Post.java
@@ -1,11 +1,11 @@
 package com.backend.immilog.post.model.entities;
 
 import com.backend.immilog.global.model.BaseDateEntity;
+import com.backend.immilog.post.application.command.PostUploadCommand;
 import com.backend.immilog.post.model.embeddables.PostMetaData;
 import com.backend.immilog.post.model.embeddables.PostUserData;
 import com.backend.immilog.post.model.enums.Categories;
 import com.backend.immilog.post.model.enums.Countries;
-import com.backend.immilog.post.presentation.request.PostUploadRequest;
 import com.backend.immilog.user.model.entities.User;
 import lombok.*;
 import org.hibernate.annotations.DynamicUpdate;
@@ -40,11 +40,11 @@ public class Post extends BaseDateEntity {
     private Long commentCount;
 
     public static Post of(
-            PostUploadRequest postUploadRequest,
+            PostUploadCommand postUploadCommand,
             User user
     ) {
         PostMetaData postMetaData = PostMetaData.of(
-                postUploadRequest,
+                postUploadCommand,
                 Countries.valueOf(user.getLocation().getCountry().toString()),
                 user.getLocation().getRegion()
         );
@@ -58,8 +58,8 @@ public class Post extends BaseDateEntity {
         return Post.builder()
                 .postUserData(postUserData)
                 .postMetaData(postMetaData)
-                .category(postUploadRequest.category())
-                .isPublic(postUploadRequest.isPublic() ? "Y" : "N")
+                .category(postUploadCommand.category())
+                .isPublic(postUploadCommand.isPublic() ? "Y" : "N")
                 .commentCount(0L)
                 .build();
     }

--- a/src/main/java/com/backend/immilog/post/model/repositories/CommentRepositoryCustom.java
+++ b/src/main/java/com/backend/immilog/post/model/repositories/CommentRepositoryCustom.java
@@ -1,6 +1,6 @@
 package com.backend.immilog.post.model.repositories;
 
-import com.backend.immilog.post.model.dtos.CommentDTO;
+import com.backend.immilog.post.application.dtos.CommentDTO;
 
 import java.util.List;
 

--- a/src/main/java/com/backend/immilog/post/model/repositories/PostRepositoryCustom.java
+++ b/src/main/java/com/backend/immilog/post/model/repositories/PostRepositoryCustom.java
@@ -1,6 +1,6 @@
 package com.backend.immilog.post.model.repositories;
 
-import com.backend.immilog.post.model.dtos.PostDTO;
+import com.backend.immilog.post.application.dtos.PostDTO;
 import com.backend.immilog.post.model.enums.Categories;
 import com.backend.immilog.post.model.enums.Countries;
 import com.backend.immilog.post.model.enums.SortingMethods;

--- a/src/main/java/com/backend/immilog/post/presentation/controller/CommentController.java
+++ b/src/main/java/com/backend/immilog/post/presentation/controller/CommentController.java
@@ -1,9 +1,9 @@
 package com.backend.immilog.post.presentation.controller;
 
-import com.backend.immilog.global.presentation.response.ApiResponse;
 import com.backend.immilog.global.security.ExtractUserId;
 import com.backend.immilog.post.application.services.CommentUploadService;
 import com.backend.immilog.post.presentation.request.CommentUploadRequest;
+import com.backend.immilog.post.presentation.response.PostApiResponse;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import lombok.RequiredArgsConstructor;
@@ -25,7 +25,7 @@ public class CommentController {
     @PostMapping("/{referenceType}/{postSeq}")
     @ExtractUserId
     @ApiOperation(value = "댓글 작성", notes = "댓글을 작성합니다.")
-    public ResponseEntity<ApiResponse> createComment(
+    public ResponseEntity<PostApiResponse> createComment(
             @PathVariable String referenceType,
             @PathVariable Long postSeq,
             HttpServletRequest request,
@@ -36,7 +36,7 @@ public class CommentController {
                 userSeq,
                 postSeq,
                 referenceType,
-                commentUploadRequest
+                commentUploadRequest.content()
         );
         return ResponseEntity.status(CREATED).build();
     }

--- a/src/main/java/com/backend/immilog/post/presentation/controller/PostController.java
+++ b/src/main/java/com/backend/immilog/post/presentation/controller/PostController.java
@@ -1,17 +1,17 @@
 package com.backend.immilog.post.presentation.controller;
 
-import com.backend.immilog.global.presentation.response.ApiResponse;
 import com.backend.immilog.global.security.ExtractUserId;
+import com.backend.immilog.post.application.dtos.PostDTO;
 import com.backend.immilog.post.application.services.PostDeleteService;
 import com.backend.immilog.post.application.services.PostInquiryService;
 import com.backend.immilog.post.application.services.PostUpdateService;
 import com.backend.immilog.post.application.services.PostUploadService;
-import com.backend.immilog.post.model.dtos.PostDTO;
 import com.backend.immilog.post.model.enums.Categories;
 import com.backend.immilog.post.model.enums.Countries;
 import com.backend.immilog.post.model.enums.SortingMethods;
 import com.backend.immilog.post.presentation.request.PostUpdateRequest;
 import com.backend.immilog.post.presentation.request.PostUploadRequest;
+import com.backend.immilog.post.presentation.response.PostApiResponse;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import lombok.RequiredArgsConstructor;
@@ -37,25 +37,25 @@ public class PostController {
     @PostMapping
     @ExtractUserId
     @ApiOperation(value = "게시물 작성", notes = "게시물을 작성합니다.")
-    public ResponseEntity<ApiResponse> createPost(
+    public ResponseEntity<PostApiResponse> createPost(
             HttpServletRequest request,
             @Valid @RequestBody PostUploadRequest postUploadRequest
     ) {
         Long userSeq = (Long) request.getAttribute("userSeq");
-        postUploadService.uploadPost(userSeq, postUploadRequest);
+        postUploadService.uploadPost(userSeq, postUploadRequest.toCommand());
         return ResponseEntity.status(CREATED).build();
     }
 
     @PatchMapping("/{postSeq}")
     @ExtractUserId
     @ApiOperation(value = "게시물 수정", notes = "게시물을 수정합니다.")
-    public ResponseEntity<ApiResponse> updatePost(
+    public ResponseEntity<PostApiResponse> updatePost(
             @PathVariable Long postSeq,
             HttpServletRequest request,
             @Valid @RequestBody PostUpdateRequest postUpdateRequest
     ) {
         Long userSeq = (Long) request.getAttribute("userSeq");
-        postUpdateService.updatePost(userSeq, postSeq, postUpdateRequest);
+        postUpdateService.updatePost(userSeq, postSeq, postUpdateRequest.toCommand());
         return ResponseEntity.status(NO_CONTENT).build();
     }
 
@@ -73,7 +73,7 @@ public class PostController {
 
     @PatchMapping("/{postSeq}/view")
     @ApiOperation(value = "게시물 조회수 증가", notes = "게시물 조회수를 증가시킵니다.")
-    public ResponseEntity<ApiResponse> increaseViewCount(
+    public ResponseEntity<PostApiResponse> increaseViewCount(
             @PathVariable Long postSeq
     ) {
         postUpdateService.increaseViewCount(postSeq);
@@ -83,7 +83,7 @@ public class PostController {
     @PatchMapping("/{postSeq}/like")
     @ExtractUserId
     @ApiOperation(value = "게시물 좋아요", notes = "게시물에 좋아요를 누릅니다.")
-    public ResponseEntity<ApiResponse> likePost(
+    public ResponseEntity<PostApiResponse> likePost(
             @PathVariable Long postSeq,
             HttpServletRequest request
     ) {
@@ -94,7 +94,7 @@ public class PostController {
 
     @GetMapping
     @ApiOperation(value = "게시물 목록 조회", notes = "게시물 목록을 조회합니다.")
-    public ResponseEntity<ApiResponse> getPosts(
+    public ResponseEntity<PostApiResponse> getPosts(
             @RequestParam(required = false) Countries country,
             @RequestParam(required = false) SortingMethods sortingMethod,
             @RequestParam(required = false) String isPublic,
@@ -108,38 +108,38 @@ public class PostController {
                 category,
                 page == null ? 0 : page
         );
-        return ResponseEntity.status(OK).body(ApiResponse.of(posts));
+        return ResponseEntity.status(OK).body(PostApiResponse.of(posts));
     }
 
     @GetMapping("/{postSeq}")
     @ApiOperation(value = "게시물 상세 조회", notes = "게시물 상세 정보를 조회합니다.")
-    public ResponseEntity<ApiResponse> getPost(
+    public ResponseEntity<PostApiResponse> getPost(
             @PathVariable Long postSeq
     ) {
         PostDTO post = postInquiryService.getPost(postSeq);
         return ResponseEntity
                 .status(OK)
-                .body(ApiResponse.of(post));
+                .body(PostApiResponse.of(post));
     }
 
     @GetMapping("/search")
     @ApiOperation(value = "게시물 검색", notes = "게시물을 검색합니다.")
-    public ResponseEntity<ApiResponse> searchPosts(
+    public ResponseEntity<PostApiResponse> searchPosts(
             @RequestParam(required = true) String keyword,
             @RequestParam(required = true) Integer page
     ) {
         Page<PostDTO> posts = postInquiryService.searchKeyword(keyword, page);
-        return ResponseEntity.status(OK).body(ApiResponse.of(posts));
+        return ResponseEntity.status(OK).body(PostApiResponse.of(posts));
     }
 
     @GetMapping("/users/{userSeq}/page/{page}")
     @ApiOperation(value = "사용자 본인의 게시물 목록 조회", notes = "사용자 게시물 목록을 조회합니다.")
-    public ResponseEntity<ApiResponse> getUserPosts(
+    public ResponseEntity<PostApiResponse> getUserPosts(
             @PathVariable Long userSeq,
             @PathVariable Integer page
     ) {
         Page<PostDTO> posts = postInquiryService.getUserPosts(userSeq, page);
-        return ResponseEntity.status(OK).body(ApiResponse.of(posts));
+        return ResponseEntity.status(OK).body(PostApiResponse.of(posts));
     }
 
 }

--- a/src/main/java/com/backend/immilog/post/presentation/request/PostUpdateRequest.java
+++ b/src/main/java/com/backend/immilog/post/presentation/request/PostUpdateRequest.java
@@ -1,9 +1,8 @@
 package com.backend.immilog.post.presentation.request;
 
+import com.backend.immilog.post.application.command.PostUpdateCommand;
 import io.swagger.annotations.ApiModel;
-import lombok.AllArgsConstructor;
 import lombok.Builder;
-import lombok.Getter;
 
 import java.util.List;
 
@@ -18,4 +17,15 @@ public record PostUpdateRequest(
         List<String> addAttachments,
         Boolean isPublic
 ) {
+    public PostUpdateCommand toCommand() {
+        return PostUpdateCommand.builder()
+                .title(title)
+                .content(content)
+                .deleteTags(deleteTags)
+                .addTags(addTags)
+                .deleteAttachments(deleteAttachments)
+                .addAttachments(addAttachments)
+                .isPublic(isPublic)
+                .build();
+    }
 }

--- a/src/main/java/com/backend/immilog/post/presentation/response/PostApiResponse.java
+++ b/src/main/java/com/backend/immilog/post/presentation/response/PostApiResponse.java
@@ -1,0 +1,23 @@
+package com.backend.immilog.post.presentation.response;
+
+import lombok.Builder;
+import org.springframework.http.HttpStatus;
+
+import java.util.List;
+
+@Builder
+public record PostApiResponse(
+        Integer status,
+        String message,
+        Object data,
+        List<Object> list
+) {
+    public static PostApiResponse of(Object data) {
+        return PostApiResponse.builder()
+                .status(HttpStatus.OK.value())
+                .message(null)
+                .data(data)
+                .list(null)
+                .build();
+    }
+}

--- a/src/main/java/com/backend/immilog/user/application/command/UserInfoUpdateCommand.java
+++ b/src/main/java/com/backend/immilog/user/application/command/UserInfoUpdateCommand.java
@@ -1,4 +1,4 @@
-package com.backend.immilog.user.application.dto;
+package com.backend.immilog.user.application.command;
 
 import com.backend.immilog.user.model.enums.UserCountry;
 import com.backend.immilog.user.model.enums.UserStatus;

--- a/src/main/java/com/backend/immilog/user/application/command/UserPasswordChangeCommand.java
+++ b/src/main/java/com/backend/immilog/user/application/command/UserPasswordChangeCommand.java
@@ -1,4 +1,4 @@
-package com.backend.immilog.user.application.dto;
+package com.backend.immilog.user.application.command;
 
 import lombok.Builder;
 

--- a/src/main/java/com/backend/immilog/user/application/command/UserReportCommand.java
+++ b/src/main/java/com/backend/immilog/user/application/command/UserReportCommand.java
@@ -1,4 +1,4 @@
-package com.backend.immilog.user.application.dto;
+package com.backend.immilog.user.application.command;
 
 import com.backend.immilog.user.enums.ReportReason;
 import lombok.Builder;

--- a/src/main/java/com/backend/immilog/user/application/command/UserSignInCommand.java
+++ b/src/main/java/com/backend/immilog/user/application/command/UserSignInCommand.java
@@ -1,4 +1,4 @@
-package com.backend.immilog.user.application.dto;
+package com.backend.immilog.user.application.command;
 
 import lombok.Builder;
 

--- a/src/main/java/com/backend/immilog/user/application/command/UserSignUpCommand.java
+++ b/src/main/java/com/backend/immilog/user/application/command/UserSignUpCommand.java
@@ -1,4 +1,4 @@
-package com.backend.immilog.user.application.dto;
+package com.backend.immilog.user.application.command;
 
 import lombok.Builder;
 

--- a/src/main/java/com/backend/immilog/user/application/dto/UserDataDTO.java
+++ b/src/main/java/com/backend/immilog/user/application/dto/UserDataDTO.java
@@ -1,4 +1,4 @@
-package com.backend.immilog.user.model.dtos;
+package com.backend.immilog.user.application.dto;
 
 import com.backend.immilog.global.enums.UserRole;
 import com.backend.immilog.user.model.entities.User;
@@ -9,7 +9,7 @@ import lombok.Builder;
 import java.sql.Date;
 
 @Builder
-public record UserDTO(
+public record UserDataDTO(
         Long seq,
         String nickName,
         String email,
@@ -22,10 +22,10 @@ public record UserDTO(
         UserRole userRole,
         UserStatus userStatus
 ) {
-    public static UserDTO from(
+    public static UserDataDTO from(
             User user
     ) {
-        return UserDTO.builder()
+        return UserDataDTO.builder()
                 .seq(user.getSeq())
                 .nickName(user.getNickName())
                 .email(user.getEmail())
@@ -40,12 +40,12 @@ public record UserDTO(
                 .build();
     }
 
-    public static UserDTO from(
+    public static UserDataDTO from(
             Long seq,
             String nickName,
             String profileImage
     ) {
-        return UserDTO.builder()
+        return UserDataDTO.builder()
                 .seq(seq)
                 .nickName(nickName)
                 .profileImage(profileImage)

--- a/src/main/java/com/backend/immilog/user/application/dto/UserSignInDTO.java
+++ b/src/main/java/com/backend/immilog/user/application/dto/UserSignInDTO.java
@@ -1,4 +1,4 @@
-package com.backend.immilog.user.model.dtos;
+package com.backend.immilog.user.application.dto;
 
 import com.backend.immilog.user.model.entities.User;
 import lombok.Builder;

--- a/src/main/java/com/backend/immilog/user/application/services/UserInformationService.java
+++ b/src/main/java/com/backend/immilog/user/application/services/UserInformationService.java
@@ -1,8 +1,8 @@
 package com.backend.immilog.user.application.services;
 
 import com.backend.immilog.global.application.ImageService;
-import com.backend.immilog.user.application.dto.UserInfoUpdateCommand;
-import com.backend.immilog.user.application.dto.UserPasswordChangeCommand;
+import com.backend.immilog.user.application.command.UserInfoUpdateCommand;
+import com.backend.immilog.user.application.command.UserPasswordChangeCommand;
 import com.backend.immilog.user.exception.UserException;
 import com.backend.immilog.user.model.entities.User;
 import com.backend.immilog.user.model.enums.UserCountry;

--- a/src/main/java/com/backend/immilog/user/application/services/UserReportService.java
+++ b/src/main/java/com/backend/immilog/user/application/services/UserReportService.java
@@ -1,7 +1,7 @@
 package com.backend.immilog.user.application.services;
 
 import com.backend.immilog.global.application.RedisDistributedLock;
-import com.backend.immilog.user.application.dto.UserReportCommand;
+import com.backend.immilog.user.application.command.UserReportCommand;
 import com.backend.immilog.user.exception.UserException;
 import com.backend.immilog.user.model.entities.Report;
 import com.backend.immilog.user.model.entities.User;

--- a/src/main/java/com/backend/immilog/user/application/services/UserSignInService.java
+++ b/src/main/java/com/backend/immilog/user/application/services/UserSignInService.java
@@ -2,9 +2,9 @@ package com.backend.immilog.user.application.services;
 
 import com.backend.immilog.global.application.RedisService;
 import com.backend.immilog.global.security.TokenProvider;
-import com.backend.immilog.user.application.dto.UserSignInCommand;
+import com.backend.immilog.user.application.command.UserSignInCommand;
 import com.backend.immilog.user.exception.UserException;
-import com.backend.immilog.user.model.dtos.UserSignInDTO;
+import com.backend.immilog.user.application.dto.UserSignInDTO;
 import com.backend.immilog.user.model.embeddables.Location;
 import com.backend.immilog.user.model.entities.User;
 import com.backend.immilog.user.model.enums.UserStatus;

--- a/src/main/java/com/backend/immilog/user/application/services/UserSignUpService.java
+++ b/src/main/java/com/backend/immilog/user/application/services/UserSignUpService.java
@@ -1,6 +1,6 @@
 package com.backend.immilog.user.application.services;
 
-import com.backend.immilog.user.application.dto.UserSignUpCommand;
+import com.backend.immilog.user.application.command.UserSignUpCommand;
 import com.backend.immilog.user.exception.UserException;
 import com.backend.immilog.user.model.entities.User;
 import com.backend.immilog.user.model.enums.UserStatus;

--- a/src/main/java/com/backend/immilog/user/model/entities/Report.java
+++ b/src/main/java/com/backend/immilog/user/model/entities/Report.java
@@ -1,7 +1,7 @@
 package com.backend.immilog.user.model.entities;
 
 import com.backend.immilog.global.model.BaseDateEntity;
-import com.backend.immilog.user.application.dto.UserReportCommand;
+import com.backend.immilog.user.application.command.UserReportCommand;
 import com.backend.immilog.user.enums.ReportReason;
 import lombok.AllArgsConstructor;
 import lombok.Builder;

--- a/src/main/java/com/backend/immilog/user/model/entities/User.java
+++ b/src/main/java/com/backend/immilog/user/model/entities/User.java
@@ -3,7 +3,7 @@ package com.backend.immilog.user.model.entities;
 import com.backend.immilog.user.model.enums.UserCountry;
 import com.backend.immilog.global.enums.UserRole;
 import com.backend.immilog.global.model.BaseDateEntity;
-import com.backend.immilog.user.application.dto.UserSignUpCommand;
+import com.backend.immilog.user.application.command.UserSignUpCommand;
 import com.backend.immilog.user.model.embeddables.Location;
 import com.backend.immilog.user.model.embeddables.ReportInfo;
 import com.backend.immilog.user.model.enums.UserStatus;

--- a/src/main/java/com/backend/immilog/user/presentation/controller/AuthController.java
+++ b/src/main/java/com/backend/immilog/user/presentation/controller/AuthController.java
@@ -1,10 +1,10 @@
 package com.backend.immilog.user.presentation.controller;
 
-import com.backend.immilog.global.presentation.response.ApiResponse;
 import com.backend.immilog.global.security.ExtractUserId;
+import com.backend.immilog.user.application.dto.UserSignInDTO;
 import com.backend.immilog.user.application.services.LocationService;
 import com.backend.immilog.user.application.services.UserSignInService;
-import com.backend.immilog.user.model.dtos.UserSignInDTO;
+import com.backend.immilog.user.presentation.response.UserApiResponse;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import lombok.RequiredArgsConstructor;
@@ -31,7 +31,7 @@ public class AuthController {
     @GetMapping("/user")
     @ExtractUserId
     @ApiOperation(value = "사용자 정보 조회", notes = "사용자 정보 조회 진행")
-    public ResponseEntity<ApiResponse> getUser(
+    public ResponseEntity<UserApiResponse> getUser(
             HttpServletRequest request,
             @RequestParam("latitude") Double latitude,
             @RequestParam("longitude") Double longitude
@@ -49,7 +49,7 @@ public class AuthController {
 
         return ResponseEntity
                 .status(OK)
-                .body(ApiResponse.of(userSignInDTO));
+                .body(UserApiResponse.of(userSignInDTO));
     }
 
 }

--- a/src/main/java/com/backend/immilog/user/presentation/controller/LocationController.java
+++ b/src/main/java/com/backend/immilog/user/presentation/controller/LocationController.java
@@ -1,9 +1,9 @@
 package com.backend.immilog.user.presentation.controller;
 
 import com.backend.immilog.global.enums.GlobalCountry;
-import com.backend.immilog.global.presentation.response.ApiResponse;
 import com.backend.immilog.user.application.services.LocationService;
 import com.backend.immilog.user.presentation.response.LocationResponse;
+import com.backend.immilog.user.presentation.response.UserApiResponse;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import lombok.RequiredArgsConstructor;
@@ -28,7 +28,7 @@ public class LocationController {
      */
     @GetMapping
     @ApiOperation(value = "위치 정보", notes = "위치 정보를 가져옵니다.")
-    public ResponseEntity<ApiResponse> getLocation(
+    public ResponseEntity<UserApiResponse> getLocation(
             @RequestParam Double latitude,
             @RequestParam Double longitude
     ) {
@@ -37,7 +37,7 @@ public class LocationController {
 
         return ResponseEntity
                 .status(OK)
-                .body(ApiResponse.of(
+                .body(UserApiResponse.of(
                                 LocationResponse.from(
                                         GlobalCountry.getCountryByKoreanName(country.getFirst()),
                                         country.getSecond()

--- a/src/main/java/com/backend/immilog/user/presentation/controller/UserController.java
+++ b/src/main/java/com/backend/immilog/user/presentation/controller/UserController.java
@@ -1,12 +1,11 @@
 package com.backend.immilog.user.presentation.controller;
 
-import com.backend.immilog.global.presentation.response.ApiResponse;
 import com.backend.immilog.global.security.ExtractUserId;
+import com.backend.immilog.user.application.dto.UserSignInDTO;
 import com.backend.immilog.user.application.services.*;
-import com.backend.immilog.user.application.services.UserReportService;
-import com.backend.immilog.user.model.dtos.UserSignInDTO;
 import com.backend.immilog.user.model.enums.UserStatus;
 import com.backend.immilog.user.presentation.request.*;
+import com.backend.immilog.user.presentation.response.UserApiResponse;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import lombok.RequiredArgsConstructor;
@@ -37,7 +36,7 @@ public class UserController {
 
     @PostMapping
     @ApiOperation(value = "사용자 회원가입", notes = "사용자 회원가입 진행")
-    public ResponseEntity<ApiResponse> signUp(
+    public ResponseEntity<UserApiResponse> signUp(
             @Valid @RequestBody UserSignUpRequest request
     ) {
         final Pair<Long, String> userSeqAndName = userSignUpService.signUp(request.toCommand());
@@ -64,7 +63,7 @@ public class UserController {
 
     @PostMapping("/sign-in")
     @ApiOperation(value = "사용자 로그인", notes = "사용자 로그인 진행")
-    public ResponseEntity<ApiResponse> signIn(
+    public ResponseEntity<UserApiResponse> signIn(
             @Valid @RequestBody UserSignInRequest request
     ) {
         CompletableFuture<Pair<String, String>> country =
@@ -73,13 +72,13 @@ public class UserController {
                         request.longitude()
                 );
         final UserSignInDTO userSignInDTO = userSignInService.signIn(request.toCommand(), country);
-        return ResponseEntity.status(OK).body(ApiResponse.of(userSignInDTO));
+        return ResponseEntity.status(OK).body(UserApiResponse.of(userSignInDTO));
     }
 
     @PatchMapping("/information")
     @ExtractUserId
     @ApiOperation(value = "사용자 정보 수정", notes = "사용자 정보 수정 진행")
-    public ResponseEntity<ApiResponse> updateInformation(
+    public ResponseEntity<UserApiResponse> updateInformation(
             HttpServletRequest request,
             @RequestBody UserInfoUpdateRequest userInfoUpdateRequest
     ) {
@@ -92,13 +91,13 @@ public class UserController {
         userInformationService.updateInformation(
                 userSeq, country, userInfoUpdateRequest.toCommand()
         );
-        return ResponseEntity.status(OK).body(ApiResponse.of(OK.value()));
+        return ResponseEntity.status(OK).body(UserApiResponse.of(OK.value()));
     }
 
     @PatchMapping("/password/change")
     @ExtractUserId
     @ApiOperation(value = "비밀번호 변경", notes = "비밀번호 변경 진행")
-    public ResponseEntity<ApiResponse> changePassword(
+    public ResponseEntity<UserApiResponse> changePassword(
             HttpServletRequest request,
             @RequestBody UserPasswordChangeRequest userPasswordChangeRequest
     ) {
@@ -114,11 +113,11 @@ public class UserController {
     @GetMapping("/nicknames")
     @ExtractUserId
     @ApiOperation(value = "닉네임 중복 체크", notes = "닉네임 중복 체크 진행")
-    public ResponseEntity<ApiResponse> checkNickname(
+    public ResponseEntity<UserApiResponse> checkNickname(
             @RequestParam String nickname
     ) {
         Boolean isNickNameAvailable = userSignUpService.checkNickname(nickname);
-        return ResponseEntity.status(OK).body(ApiResponse.of(isNickNameAvailable));
+        return ResponseEntity.status(OK).body(UserApiResponse.of(isNickNameAvailable));
     }
 
     @PatchMapping("/{userSeq}/{status}")

--- a/src/main/java/com/backend/immilog/user/presentation/request/UserInfoUpdateRequest.java
+++ b/src/main/java/com/backend/immilog/user/presentation/request/UserInfoUpdateRequest.java
@@ -1,6 +1,6 @@
 package com.backend.immilog.user.presentation.request;
 
-import com.backend.immilog.user.application.dto.UserInfoUpdateCommand;
+import com.backend.immilog.user.application.command.UserInfoUpdateCommand;
 import com.backend.immilog.user.model.enums.UserCountry;
 import com.backend.immilog.user.model.enums.UserStatus;
 import io.swagger.annotations.ApiModel;

--- a/src/main/java/com/backend/immilog/user/presentation/request/UserPasswordChangeRequest.java
+++ b/src/main/java/com/backend/immilog/user/presentation/request/UserPasswordChangeRequest.java
@@ -1,6 +1,6 @@
 package com.backend.immilog.user.presentation.request;
 
-import com.backend.immilog.user.application.dto.UserPasswordChangeCommand;
+import com.backend.immilog.user.application.command.UserPasswordChangeCommand;
 import io.swagger.annotations.ApiModel;
 import lombok.Builder;
 

--- a/src/main/java/com/backend/immilog/user/presentation/request/UserReportRequest.java
+++ b/src/main/java/com/backend/immilog/user/presentation/request/UserReportRequest.java
@@ -1,6 +1,6 @@
 package com.backend.immilog.user.presentation.request;
 
-import com.backend.immilog.user.application.dto.UserReportCommand;
+import com.backend.immilog.user.application.command.UserReportCommand;
 import com.backend.immilog.user.enums.ReportReason;
 import io.swagger.annotations.ApiModel;
 import lombok.Builder;

--- a/src/main/java/com/backend/immilog/user/presentation/request/UserSignInRequest.java
+++ b/src/main/java/com/backend/immilog/user/presentation/request/UserSignInRequest.java
@@ -1,6 +1,6 @@
 package com.backend.immilog.user.presentation.request;
 
-import com.backend.immilog.user.application.dto.UserSignInCommand;
+import com.backend.immilog.user.application.command.UserSignInCommand;
 import io.swagger.annotations.ApiModel;
 import lombok.Builder;
 

--- a/src/main/java/com/backend/immilog/user/presentation/request/UserSignUpRequest.java
+++ b/src/main/java/com/backend/immilog/user/presentation/request/UserSignUpRequest.java
@@ -1,6 +1,6 @@
 package com.backend.immilog.user.presentation.request;
 
-import com.backend.immilog.user.application.dto.UserSignUpCommand;
+import com.backend.immilog.user.application.command.UserSignUpCommand;
 import io.swagger.annotations.ApiModel;
 import lombok.Builder;
 

--- a/src/main/java/com/backend/immilog/user/presentation/response/UserApiResponse.java
+++ b/src/main/java/com/backend/immilog/user/presentation/response/UserApiResponse.java
@@ -1,0 +1,23 @@
+package com.backend.immilog.user.presentation.response;
+
+import lombok.Builder;
+import org.springframework.http.HttpStatus;
+
+import java.util.List;
+
+@Builder
+public record UserApiResponse(
+        Integer status,
+        String message,
+        Object data,
+        List<Object> list
+) {
+    public static UserApiResponse of(Object data) {
+        return UserApiResponse.builder()
+                .status(HttpStatus.OK.value())
+                .message(null)
+                .data(data)
+                .list(null)
+                .build();
+    }
+}

--- a/src/test/java/com/backend/immilog/global/presentation/controller/ImageControllerTest.java
+++ b/src/test/java/com/backend/immilog/global/presentation/controller/ImageControllerTest.java
@@ -2,7 +2,7 @@ package com.backend.immilog.global.presentation.controller;
 
 import com.backend.immilog.global.application.ImageService;
 import com.backend.immilog.global.presentation.request.ImageRequest;
-import com.backend.immilog.global.presentation.response.ApiResponse;
+import com.backend.immilog.global.presentation.response.GlobalApiResponse;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -41,7 +41,7 @@ class ImageControllerTest {
         when(imageService.saveFiles(files, imagePath))
                 .thenReturn(imageDTO);
         // when
-        ResponseEntity<ApiResponse> response =
+        ResponseEntity<GlobalApiResponse> response =
                 imageController.uploadImage(files, imagePath);
         // then
         assertThat(response.getStatusCode()).isEqualTo(OK);
@@ -59,7 +59,7 @@ class ImageControllerTest {
                 .imagePath(imagePath)
                 .build();
         // when
-        ResponseEntity<ApiResponse> response = imageController.deleteImage(param);
+        ResponseEntity<GlobalApiResponse> response = imageController.deleteImage(param);
         // then
         verify(imageService, times(1)).deleteFile(imagePath);
         assertThat(response.getStatusCode()).isEqualTo(NO_CONTENT);

--- a/src/test/java/com/backend/immilog/notice/application/NoticeInquiryServiceTest.java
+++ b/src/test/java/com/backend/immilog/notice/application/NoticeInquiryServiceTest.java
@@ -1,6 +1,7 @@
 package com.backend.immilog.notice.application;
 
-import com.backend.immilog.notice.model.dtos.NoticeDTO;
+import com.backend.immilog.notice.application.services.NoticeInquiryService;
+import com.backend.immilog.notice.application.dtos.NoticeDTO;
 import com.backend.immilog.notice.model.entities.Notice;
 import com.backend.immilog.notice.model.enums.NoticeType;
 import com.backend.immilog.notice.model.repositories.NoticeRepository;

--- a/src/test/java/com/backend/immilog/notice/application/NoticeRegisterServiceTest.java
+++ b/src/test/java/com/backend/immilog/notice/application/NoticeRegisterServiceTest.java
@@ -1,6 +1,7 @@
 package com.backend.immilog.notice.application;
 
 import com.backend.immilog.global.enums.UserRole;
+import com.backend.immilog.notice.application.services.NoticeRegisterService;
 import com.backend.immilog.notice.model.enums.NoticeType;
 import com.backend.immilog.notice.model.repositories.NoticeRepository;
 import com.backend.immilog.notice.presentation.request.NoticeRegisterRequest;
@@ -42,7 +43,7 @@ class NoticeRegisterServiceTest {
                 .type(NoticeType.NOTICE)
                 .build();
         // when
-        noticeRegisterService.registerNotice(userSeq, userRole, param);
+        noticeRegisterService.registerNotice(userSeq, userRole, param.toCommand());
         // then
         verify(noticeRepository, times(1)).save(any());
     }

--- a/src/test/java/com/backend/immilog/notice/presentation/controller/NoticeControllerTest.java
+++ b/src/test/java/com/backend/immilog/notice/presentation/controller/NoticeControllerTest.java
@@ -1,11 +1,11 @@
 package com.backend.immilog.notice.presentation.controller;
 
 import com.backend.immilog.global.enums.UserRole;
-import com.backend.immilog.global.presentation.response.ApiResponse;
-import com.backend.immilog.notice.application.NoticeInquiryService;
-import com.backend.immilog.notice.application.NoticeRegisterService;
+import com.backend.immilog.notice.application.services.NoticeInquiryService;
+import com.backend.immilog.notice.application.services.NoticeRegisterService;
 import com.backend.immilog.notice.model.enums.NoticeType;
 import com.backend.immilog.notice.presentation.request.NoticeRegisterRequest;
+import com.backend.immilog.notice.presentation.response.NoticeApiResponse;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -56,10 +56,10 @@ class NoticeControllerTest {
 
 
         // when
-        ResponseEntity<ApiResponse> response = noticeController.registerNotice(param, request);
+        ResponseEntity<NoticeApiResponse> response = noticeController.registerNotice(param, request);
 
         // then
-        verify(noticeRegisterService).registerNotice(userSeq, userRole, param);
+        verify(noticeRegisterService).registerNotice(userSeq, userRole, param.toCommand());
         assertThat(response.getStatusCodeValue()).isEqualTo(201);
 
     }
@@ -75,7 +75,7 @@ class NoticeControllerTest {
         when(noticeInquiryService.getNotices(userSeq, page)).thenReturn(null);
 
         // when
-        ResponseEntity<ApiResponse> response = noticeController.getNotices(page, request);
+        ResponseEntity<NoticeApiResponse> response = noticeController.getNotices(page, request);
 
         // then
         verify(noticeInquiryService).getNotices(userSeq, page);
@@ -90,7 +90,7 @@ class NoticeControllerTest {
         when(noticeInquiryService.getNoticeDetail(noticeSeq)).thenReturn(null);
 
         // when
-        ResponseEntity<ApiResponse> response = noticeController.getNoticeDetail(noticeSeq);
+        ResponseEntity<NoticeApiResponse> response = noticeController.getNoticeDetail(noticeSeq);
 
         // then
         verify(noticeInquiryService).getNoticeDetail(noticeSeq);

--- a/src/test/java/com/backend/immilog/post/application/CommentUploadServiceTest.java
+++ b/src/test/java/com/backend/immilog/post/application/CommentUploadServiceTest.java
@@ -52,7 +52,7 @@ class CommentUploadServiceTest {
                 userId,
                 postSeq,
                 referenceType,
-                commentUploadRequest
+                commentUploadRequest.content()
         );
         // then
         verify(postRepository, times(1)).findById(postSeq);
@@ -74,7 +74,7 @@ class CommentUploadServiceTest {
                 userId,
                 postSeq,
                 referenceType,
-                commentUploadRequest
+                commentUploadRequest.content()
         ))
                 .isInstanceOf(PostException.class)
                 .hasMessage(POST_NOT_FOUND.getMessage());
@@ -96,7 +96,7 @@ class CommentUploadServiceTest {
                 userId,
                 postSeq,
                 referenceType,
-                commentUploadRequest
+                commentUploadRequest.content()
         ))
                 .isInstanceOf(PostException.class)
                 .hasMessage(INVALID_REFERENCE_TYPE.getMessage());

--- a/src/test/java/com/backend/immilog/post/application/PostInquiryServiceTest.java
+++ b/src/test/java/com/backend/immilog/post/application/PostInquiryServiceTest.java
@@ -3,7 +3,7 @@ package com.backend.immilog.post.application;
 import com.backend.immilog.post.application.services.PostInquiryService;
 import com.backend.immilog.post.model.enums.Categories;
 import com.backend.immilog.post.model.enums.SortingMethods;
-import com.backend.immilog.post.model.dtos.PostDTO;
+import com.backend.immilog.post.application.dtos.PostDTO;
 import com.backend.immilog.post.model.repositories.CommentRepository;
 import com.backend.immilog.post.model.repositories.PostRepository;
 import com.backend.immilog.post.model.enums.Countries;

--- a/src/test/java/com/backend/immilog/post/application/PostUpdateServiceTest.java
+++ b/src/test/java/com/backend/immilog/post/application/PostUpdateServiceTest.java
@@ -100,7 +100,7 @@ class PostUpdateServiceTest {
                 ArgumentCaptor.forClass(BiConsumer.class);
 
         // when
-        postUpdateService.updatePost(userSeq, postSeq, postUpdateRequest);
+        postUpdateService.updatePost(userSeq, postSeq, postUpdateRequest.toCommand());
 
         // then
         verify(postResourceRepository, times(2))
@@ -148,7 +148,8 @@ class PostUpdateServiceTest {
 
         // when & then
         assertThatThrownBy(() ->
-                postUpdateService.updatePost(userSeq, postSeq, postUpdateRequest))
+                postUpdateService.updatePost(userSeq, postSeq,
+                        postUpdateRequest.toCommand()))
                 .isInstanceOf(PostException.class)
                 .hasMessage(FAILED_TO_SAVE_POST.getMessage());
 

--- a/src/test/java/com/backend/immilog/post/application/PostUploadServiceTest.java
+++ b/src/test/java/com/backend/immilog/post/application/PostUploadServiceTest.java
@@ -97,7 +97,7 @@ class PostUploadServiceTest {
                 ArgumentCaptor.forClass(BiConsumer.class);
 
         // when
-        postUploadService.uploadPost(userSeq, postUploadRequest);
+        postUploadService.uploadPost(userSeq, postUploadRequest.toCommand());
 
         // then
         verify(postRepository).save(any(Post.class));
@@ -145,7 +145,7 @@ class PostUploadServiceTest {
         when(postRepository.save(any(Post.class))).thenReturn(post);
 
         // when
-        postUploadService.uploadPost(userSeq, postUploadRequest);
+        postUploadService.uploadPost(userSeq, postUploadRequest.toCommand());
 
         // then
         verify(postRepository).save(any(Post.class));
@@ -185,7 +185,7 @@ class PostUploadServiceTest {
 
         // when & then
         assertThatThrownBy(() ->
-                postUploadService.uploadPost(userSeq, postUploadRequest)
+                postUploadService.uploadPost(userSeq, postUploadRequest.toCommand())
         )
                 .isInstanceOf(PostException.class)
                 .hasMessage(FAILED_TO_SAVE_POST.getMessage());

--- a/src/test/java/com/backend/immilog/post/presentation/controller/PostControllerTest.java
+++ b/src/test/java/com/backend/immilog/post/presentation/controller/PostControllerTest.java
@@ -1,15 +1,15 @@
 package com.backend.immilog.post.presentation.controller;
 
-import com.backend.immilog.global.presentation.response.ApiResponse;
+import com.backend.immilog.post.application.dtos.PostDTO;
 import com.backend.immilog.post.application.services.PostDeleteService;
 import com.backend.immilog.post.application.services.PostInquiryService;
 import com.backend.immilog.post.application.services.PostUpdateService;
 import com.backend.immilog.post.application.services.PostUploadService;
-import com.backend.immilog.post.model.dtos.PostDTO;
 import com.backend.immilog.post.model.enums.Categories;
 import com.backend.immilog.post.model.enums.SortingMethods;
 import com.backend.immilog.post.presentation.request.PostUpdateRequest;
 import com.backend.immilog.post.presentation.request.PostUploadRequest;
+import com.backend.immilog.post.presentation.response.PostApiResponse;
 import com.backend.immilog.user.model.embeddables.Location;
 import com.backend.immilog.user.model.entities.User;
 import com.backend.immilog.user.model.enums.UserCountry;
@@ -75,13 +75,13 @@ class PostControllerTest {
         when(request.getAttribute("userSeq")).thenReturn(1L);
 
         // when
-        ResponseEntity<ApiResponse> response = postController.createPost(
+        ResponseEntity<PostApiResponse> response = postController.createPost(
                 request,
                 postUploadRequest
         );
 
         // then
-        verify(postUploadService).uploadPost(user.getSeq(), postUploadRequest);
+        verify(postUploadService).uploadPost(user.getSeq(), postUploadRequest.toCommand());
         assertThat(response.getStatusCode()).isEqualTo(ResponseEntity.status(CREATED).build().getStatusCode());
     }
 
@@ -103,14 +103,14 @@ class PostControllerTest {
                 .build();
 
         // when
-        ResponseEntity<ApiResponse> response = postController.updatePost(
+        ResponseEntity<PostApiResponse> response = postController.updatePost(
                 postSeq,
                 request,
                 postUpdateRequest
         );
 
         // then
-        verify(postUpdateService).updatePost(1L, postSeq, postUpdateRequest);
+        verify(postUpdateService).updatePost(1L, postSeq, postUpdateRequest.toCommand());
         assertThat(response.getStatusCode()).isEqualTo(NO_CONTENT);
     }
 
@@ -140,8 +140,7 @@ class PostControllerTest {
         Long postSeq = 1L;
 
         // when
-        ResponseEntity<ApiResponse> response =
-                postController.increaseViewCount(postSeq);
+        ResponseEntity<PostApiResponse> response = postController.increaseViewCount(postSeq);
 
         // then
         verify(postUpdateService).increaseViewCount(postSeq);
@@ -157,7 +156,7 @@ class PostControllerTest {
         when(request.getAttribute("userSeq")).thenReturn(1L);
 
         // when
-        ResponseEntity<ApiResponse> response = postController.likePost(
+        ResponseEntity<PostApiResponse> response = postController.likePost(
                 postSeq,
                 request
         );
@@ -186,7 +185,7 @@ class PostControllerTest {
         )).thenReturn(posts);
 
         // when
-        ResponseEntity<ApiResponse> response = postController.getPosts(
+        ResponseEntity<PostApiResponse> response = postController.getPosts(
                 com.backend.immilog.post.model.enums.Countries.SOUTH_KOREA,
                 sortingMethod,
                 isPublic,
@@ -211,7 +210,7 @@ class PostControllerTest {
         when(postDTO.getSeq()).thenReturn(postSeq);
 
         // when
-        ResponseEntity<ApiResponse> response = postController.getPost(postSeq);
+        ResponseEntity<PostApiResponse> response = postController.getPost(postSeq);
 
         // then
         assertThat(response.getStatusCode()).isEqualTo(OK);
@@ -233,7 +232,7 @@ class PostControllerTest {
         )).thenReturn(posts);
 
         // when
-        ResponseEntity<ApiResponse> response = postController.searchPosts(
+        ResponseEntity<PostApiResponse> response = postController.searchPosts(
                 keyword,
                 page
         );
@@ -258,7 +257,7 @@ class PostControllerTest {
         )).thenReturn(posts);
 
         // when
-        ResponseEntity<ApiResponse> response = postController.getUserPosts(
+        ResponseEntity<PostApiResponse> response = postController.getUserPosts(
                 userSeq,
                 page
         );

--- a/src/test/java/com/backend/immilog/user/application/UserInformationServiceTest.java
+++ b/src/test/java/com/backend/immilog/user/application/UserInformationServiceTest.java
@@ -1,7 +1,7 @@
 package com.backend.immilog.user.application;
 
 import com.backend.immilog.global.application.ImageService;
-import com.backend.immilog.user.application.dto.UserPasswordChangeCommand;
+import com.backend.immilog.user.application.command.UserPasswordChangeCommand;
 import com.backend.immilog.user.application.services.UserInformationService;
 import com.backend.immilog.user.exception.UserException;
 import com.backend.immilog.user.model.embeddables.Location;

--- a/src/test/java/com/backend/immilog/user/application/UserSignInServiceTest.java
+++ b/src/test/java/com/backend/immilog/user/application/UserSignInServiceTest.java
@@ -6,7 +6,7 @@ import com.backend.immilog.global.enums.UserRole;
 import com.backend.immilog.global.security.TokenProvider;
 import com.backend.immilog.user.application.services.UserSignInService;
 import com.backend.immilog.user.exception.UserException;
-import com.backend.immilog.user.model.dtos.UserSignInDTO;
+import com.backend.immilog.user.application.dto.UserSignInDTO;
 import com.backend.immilog.user.model.embeddables.Location;
 import com.backend.immilog.user.model.entities.User;
 import com.backend.immilog.user.model.enums.UserStatus;

--- a/src/test/java/com/backend/immilog/user/presentation/controller/AuthControllerTest.java
+++ b/src/test/java/com/backend/immilog/user/presentation/controller/AuthControllerTest.java
@@ -1,9 +1,9 @@
 package com.backend.immilog.user.presentation.controller;
 
-import com.backend.immilog.global.presentation.response.ApiResponse;
+import com.backend.immilog.user.application.dto.UserSignInDTO;
 import com.backend.immilog.user.application.services.LocationService;
 import com.backend.immilog.user.application.services.UserSignInService;
-import com.backend.immilog.user.model.dtos.UserSignInDTO;
+import com.backend.immilog.user.presentation.response.UserApiResponse;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -68,7 +68,7 @@ class AuthControllerTest {
         when(request.getAttribute("userSeq")).thenReturn(1L);
 
         // when
-        ResponseEntity<ApiResponse> response =
+        ResponseEntity<UserApiResponse> response =
                 authController.getUser(request, latitude, longitude);
 
         // then

--- a/src/test/java/com/backend/immilog/user/presentation/controller/LocationControllerTest.java
+++ b/src/test/java/com/backend/immilog/user/presentation/controller/LocationControllerTest.java
@@ -1,9 +1,10 @@
 package com.backend.immilog.user.presentation.controller;
 
 import com.backend.immilog.global.enums.GlobalCountry;
-import com.backend.immilog.global.presentation.response.ApiResponse;
+
 import com.backend.immilog.user.application.services.LocationService;
 import com.backend.immilog.user.presentation.response.LocationResponse;
+import com.backend.immilog.user.presentation.response.UserApiResponse;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -55,7 +56,7 @@ class LocationControllerTest {
         assertThat(response).isNotNull();
         assertThat(OK).isEqualTo(response.getStatusCode());
         LocationResponse locationResponse =
-                (LocationResponse) ((ApiResponse) Objects.requireNonNull(response.getBody())).data();
+                (LocationResponse) ((UserApiResponse) Objects.requireNonNull(response.getBody())).data();
         assertThat(locationResponse).isNotNull();
         assertThat(GlobalCountry.getCountryByKoreanName(country).getCountryName())
                 .isEqualTo(locationResponse.country());

--- a/src/test/java/com/backend/immilog/user/presentation/controller/UserControllerTest.java
+++ b/src/test/java/com/backend/immilog/user/presentation/controller/UserControllerTest.java
@@ -1,11 +1,11 @@
 package com.backend.immilog.user.presentation.controller;
 
-import com.backend.immilog.global.presentation.response.ApiResponse;
+
+import com.backend.immilog.user.application.dto.UserSignInDTO;
 import com.backend.immilog.user.application.services.*;
-import com.backend.immilog.user.application.services.UserReportService;
 import com.backend.immilog.user.enums.EmailComponents;
-import com.backend.immilog.user.model.dtos.UserSignInDTO;
 import com.backend.immilog.user.presentation.request.*;
+import com.backend.immilog.user.presentation.response.UserApiResponse;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -19,9 +19,9 @@ import javax.servlet.http.HttpServletRequest;
 import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
 
+import static com.backend.immilog.user.enums.ReportReason.FRAUD;
 import static com.backend.immilog.user.model.enums.UserCountry.INDONESIA;
 import static com.backend.immilog.user.model.enums.UserCountry.JAPAN;
-import static com.backend.immilog.user.enums.ReportReason.FRAUD;
 import static com.backend.immilog.user.model.enums.UserStatus.ACTIVE;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.*;
@@ -75,7 +75,7 @@ class UserControllerTest {
                 .thenReturn(Pair.of(1L, "test"));
 
         // when
-        ResponseEntity<ApiResponse> response = userController.signUp(param);
+        ResponseEntity<UserApiResponse> response = userController.signUp(param);
 
         // then
         verify(emailService, times(1)).sendHtmlEmail(
@@ -130,7 +130,7 @@ class UserControllerTest {
                 locationService.getCountry(param.latitude(), param.longitude()))
         ).thenReturn(UserSignInDTO.builder().build());
         // when
-        ResponseEntity<ApiResponse> response = userController.signIn(param);
+        ResponseEntity<UserApiResponse> response = userController.signIn(param);
 
         // then
         assertThat(response.getStatusCode()).isEqualTo(OK);
@@ -156,7 +156,7 @@ class UserControllerTest {
         when(locationService.getCountry(param.latitude(), param.longitude()))
                 .thenReturn(CompletableFuture.completedFuture(Pair.of("Japan", "Tokyo")));
         // when
-        ResponseEntity<ApiResponse> response =
+        ResponseEntity<UserApiResponse> response =
                 userController.updateInformation(request, param);
 
         // then
@@ -179,7 +179,7 @@ class UserControllerTest {
                 .build();
         when(request.getAttribute("userSeq")).thenReturn(1L);
         // when
-        ResponseEntity<ApiResponse> response =
+        ResponseEntity<UserApiResponse> response =
                 userController.changePassword(request, param);
 
         // then
@@ -196,11 +196,11 @@ class UserControllerTest {
         when(userSignUpService.checkNickname(nickname)).thenReturn(true);
 
         // when
-        ResponseEntity<ApiResponse> response =
+        ResponseEntity<UserApiResponse> response =
                 userController.checkNickname(nickname);
 
         // then
-        ApiResponse body = Objects.requireNonNull(response.getBody());
+        UserApiResponse body = Objects.requireNonNull(response.getBody());
         assertThat(body.data()).isEqualTo(true);
     }
 


### PR DESCRIPTION
* refactor (global) : 계층별 DTO를 분리하여 유지보수성과 명확성 개선

- Presentation 계층의 DTO와 Application/Service 계층의 DTO를 분리함
- UserApiResponse를 Presentation 계층 DTO로 정의하여 클라이언트 응답에 최적화
- UserDto를 Application 계층의 DTO로 정의하여 비즈니스 로직과 도메인 모델 간의 데이터 전송을 명확히 함
- 패키지 구조를 리팩토링하여 각 DTO의 책임과 위치를 명확히 분리

* refactor (notice) : 계층별 DTO를 분리하여 유지보수성과 명확성 개선

- Presentation 계층의 DTO와 Application/Service 계층의 DTO를 분리함
- UserApiResponse를 Presentation 계층 DTO로 정의하여 클라이언트 응답에 최적화
- UserDto를 Application 계층의 DTO로 정의하여 비즈니스 로직과 도메인 모델 간의 데이터 전송을 명확히 함
- 패키지 구조를 리팩토링하여 각 DTO의 책임과 위치를 명확히 분리

* refactor (post) : 계층별 DTO를 분리하여 유지보수성과 명확성 개선

- Presentation 계층의 DTO와 Application/Service 계층의 DTO를 분리함
- UserApiResponse를 Presentation 계층 DTO로 정의하여 클라이언트 응답에 최적화
- UserDto를 Application 계층의 DTO로 정의하여 비즈니스 로직과 도메인 모델 간의 데이터 전송을 명확히 함
- 패키지 구조를 리팩토링하여 각 DTO의 책임과 위치를 명확히 분리

* refactor (user) : 계층별 DTO를 분리하여 유지보수성과 명확성 개선

- Presentation 계층의 DTO와 Application/Service 계층의 DTO를 분리함
- UserApiResponse를 Presentation 계층 DTO로 정의하여 클라이언트 응답에 최적화
- UserDto를 Application 계층의 DTO로 정의하여 비즈니스 로직과 도메인 모델 간의 데이터 전송을 명확히 함
- 패키지 구조를 리팩토링하여 각 DTO의 책임과 위치를 명확히 분리

* test (user) : 계층별 DTO를 분리에 따른 테스트코드 수정

- Presentation 계층의 DTO와 Application/Service 계층의 DTO를 분리함
- UserApiResponse를 Presentation 계층 DTO로 정의하여 클라이언트 응답에 최적화
- UserDto를 Application 계층의 DTO로 정의하여 비즈니스 로직과 도메인 모델 간의 데이터 전송을 명확히 함
- 패키지 구조를 리팩토링하여 각 DTO의 책임과 위치를 명확히 분리

* test (post) : 계층별 DTO를 분리에 따른 테스트코드 수정

- Presentation 계층의 DTO와 Application/Service 계층의 DTO를 분리함
- UserApiResponse를 Presentation 계층 DTO로 정의하여 클라이언트 응답에 최적화
- UserDto를 Application 계층의 DTO로 정의하여 비즈니스 로직과 도메인 모델 간의 데이터 전송을 명확히 함
- 패키지 구조를 리팩토링하여 각 DTO의 책임과 위치를 명확히 분리

* test (notice) : 계층별 DTO를 분리에 따른 테스트코드 수정

- Presentation 계층의 DTO와 Application/Service 계층의 DTO를 분리함
- UserApiResponse를 Presentation 계층 DTO로 정의하여 클라이언트 응답에 최적화
- UserDto를 Application 계층의 DTO로 정의하여 비즈니스 로직과 도메인 모델 간의 데이터 전송을 명확히 함
- 패키지 구조를 리팩토링하여 각 DTO의 책임과 위치를 명확히 분리

* test (global) : 계층별 DTO를 분리에 따른 테스트코드 수정

- Presentation 계층의 DTO와 Application/Service 계층의 DTO를 분리함
- UserApiResponse를 Presentation 계층 DTO로 정의하여 클라이언트 응답에 최적화
- UserDto를 Application 계층의 DTO로 정의하여 비즈니스 로직과 도메인 모델 간의 데이터 전송을 명확히 함
- 패키지 구조를 리팩토링하여 각 DTO의 책임과 위치를 명확히 분리