### PR TITLE
feat (global) : RedisTemplate / S3 Bucket 인터페이스로 추상화  (#254)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # base 이미지 설정
-FROM eclipse-temurin:18
+FROM eclipse-temurin:21
 
 # jar 파일 위치를 변수로 설정
 ARG JAR_FILE=/build/libs/*-SNAPSHOT.jar

--- a/build.gradle
+++ b/build.gradle
@@ -14,8 +14,8 @@ group = 'com'
 version = '0.0.1-SNAPSHOT'
 
 java {
-    sourceCompatibility = JavaVersion.VERSION_18
-    targetCompatibility = JavaVersion.VERSION_18
+    sourceCompatibility = JavaVersion.VERSION_21
+    targetCompatibility = JavaVersion.VERSION_21
 }
 
 configurations {

--- a/src/main/java/com/backend/immilog/global/application/ImageService.java
+++ b/src/main/java/com/backend/immilog/global/application/ImageService.java
@@ -1,100 +1,27 @@
 package com.backend.immilog.global.application;
 
-
-import com.amazonaws.services.s3.AmazonS3;
-import com.amazonaws.services.s3.model.ObjectMetadata;
-import com.backend.immilog.global.exception.CustomException;
+import com.backend.immilog.global.infrastructure.storage.FileStorageHandler;
 import lombok.RequiredArgsConstructor;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 
-import java.io.IOException;
 import java.util.List;
-import java.util.UUID;
-
-import static com.backend.immilog.global.exception.CommonErrorCode.IMAGE_UPLOAD_FAILED;
 
 @RequiredArgsConstructor
 @Service
 public class ImageService {
-    private final AmazonS3 amazonS3;
-
-    @Value("${cloud.aws.s3.bucket}")
-    private String bucket;
+    private final FileStorageHandler fileStorageHandler;
 
     public List<String> saveFiles(
             List<MultipartFile> multipartFiles,
             String imagePath
     ) {
         return multipartFiles.stream()
-                .map(multipartFile -> saveFileAndGetUrl(multipartFile, imagePath))
+                .map(multipartFile -> fileStorageHandler.uploadFile(multipartFile, imagePath))
                 .toList();
     }
 
-    public void deleteFile(
-            String imagePath
-    ) {
-        amazonS3.deleteObject(bucket, imagePath);
-    }
-
-    private String saveFileAndGetUrl(
-            MultipartFile multipartFile,
-            String imagePath
-    ) {
-        String originalFileName = generateFileName(multipartFile, imagePath);
-        uploadFileToS3(multipartFile, originalFileName);
-        return generateFileUrl(originalFileName);
-    }
-
-    private String generateFileName(
-            MultipartFile multipartFile,
-            String imagePath
-    ) {
-        return imagePath + "/" +
-                UUID.randomUUID()
-                        .toString()
-                        .replace("-", "")
-                        .substring(0, 16)
-                + "." + getFileExtension(multipartFile);
-    }
-
-    private void uploadFileToS3(
-            MultipartFile multipartFile,
-            String originalFileName
-    ) {
-        ObjectMetadata metadata = new ObjectMetadata();
-        metadata.setContentLength(multipartFile.getSize());
-        metadata.setContentType(multipartFile.getContentType());
-
-        try {
-            amazonS3.putObject(
-                    bucket,
-                    originalFileName,
-                    multipartFile.getInputStream(),
-                    metadata
-            );
-        } catch (IOException e) {
-            throw new CustomException(IMAGE_UPLOAD_FAILED);
-        }
-    }
-
-    private String generateFileUrl(
-            String originalFileName
-    ) {
-        return amazonS3.getUrl(bucket, originalFileName).toString();
-    }
-
-    private String getFileExtension(
-            MultipartFile file
-    ) {
-        String originalFilename = file.getOriginalFilename();
-        if (originalFilename != null) {
-            int lastDotIndex = originalFilename.lastIndexOf(".");
-            if (lastDotIndex != -1) {
-                return originalFilename.substring(lastDotIndex + 1);
-            }
-        }
-        return "png"; // 확장자가 없는 경우 png 반환
+    public void deleteFile(String imagePath) {
+        fileStorageHandler.deleteFile(imagePath);
     }
 }

--- a/src/main/java/com/backend/immilog/global/application/RedisService.java
+++ b/src/main/java/com/backend/immilog/global/application/RedisService.java
@@ -1,40 +1,34 @@
 package com.backend.immilog.global.application;
 
+import com.backend.immilog.global.infrastructure.repository.DataRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.data.redis.core.RedisTemplate;
-import org.springframework.data.redis.core.ValueOperations;
 import org.springframework.stereotype.Service;
-
-import static java.util.concurrent.TimeUnit.MINUTES;
 
 @Slf4j
 @Service
 @RequiredArgsConstructor
 public class RedisService {
-    private final RedisTemplate<String, String> stringRedisTemplate;
+    private final DataRepository dataRepository;
 
     public void saveKeyAndValue(
             String key,
             String value,
             int expireTime
     ) {
-        ValueOperations<String, String> ops = stringRedisTemplate.opsForValue();
-        ops.set(key, value);
-        stringRedisTemplate.expire(key, expireTime, MINUTES);
+        dataRepository.save(key, value, expireTime);
     }
 
     public String getValueByKey(
-            String refreshToken
+            String key
     ) {
-        ValueOperations<String, String> ops = stringRedisTemplate.opsForValue();
-        return ops.get(refreshToken);
+        return dataRepository.findByKey(key);
     }
 
     public void deleteValueByKey(
-            String refreshToken
+            String key
     ) {
-        stringRedisTemplate.delete(refreshToken);
+        dataRepository.deleteByKey(key);
     }
 }
 

--- a/src/main/java/com/backend/immilog/global/configuration/AsyncConfig.java
+++ b/src/main/java/com/backend/immilog/global/configuration/AsyncConfig.java
@@ -5,24 +5,21 @@ import org.springframework.aop.interceptor.AsyncUncaughtExceptionHandler;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.scheduling.annotation.AsyncConfigurerSupport;
 import org.springframework.scheduling.annotation.EnableAsync;
-import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
 
 import java.util.concurrent.Executor;
+import java.util.concurrent.Executors;
+
 
 @Configuration
 @EnableAsync
 public class AsyncConfig extends AsyncConfigurerSupport {
 
+    @Override
     public Executor getAsyncExecutor() {
-        ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
-        executor.setCorePoolSize(2); // 디폴트로 실행 대기 중인 Thread 수
-        executor.setMaxPoolSize(10); // 동시에 동작하는 최대 Thread 수
-        executor.setQueueCapacity(20); // CorePool이 초과될때 Queue에 저장했다가 꺼내서 실행. (20개까지 저장)
-        executor.setThreadNamePrefix("async-"); // Spring에서 생성하는 Thread 접두사
-        executor.initialize();
-        return executor;
+        return Executors.newVirtualThreadPerTaskExecutor();
     }
 
+    @Override
     public AsyncUncaughtExceptionHandler getAsyncUncaughtExceptionHandler() {
         return new AsyncUncaughtExceptionHandlerCustom();
     }

--- a/src/main/java/com/backend/immilog/global/infrastructure/repository/DataRepository.java
+++ b/src/main/java/com/backend/immilog/global/infrastructure/repository/DataRepository.java
@@ -1,0 +1,24 @@
+package com.backend.immilog.global.infrastructure.repository;
+
+public interface DataRepository {
+    void save(
+            String key,
+            String value,
+            int expireTime
+    );
+
+    String findByKey(
+            String key
+    );
+
+    void deleteByKey(
+            String key
+    );
+
+    Boolean saveIfAbsent(
+            String key,
+            String value,
+            long expireTimeInSeconds
+    );
+
+}

--- a/src/main/java/com/backend/immilog/global/infrastructure/repository/RedisDataRepository.java
+++ b/src/main/java/com/backend/immilog/global/infrastructure/repository/RedisDataRepository.java
@@ -1,0 +1,51 @@
+package com.backend.immilog.global.infrastructure.repository;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+import org.springframework.stereotype.Repository;
+
+import static java.util.concurrent.TimeUnit.MINUTES;
+import static java.util.concurrent.TimeUnit.SECONDS;
+
+@Repository
+@RequiredArgsConstructor
+public class RedisDataRepository implements DataRepository {
+    private final RedisTemplate<String, String> stringRedisTemplate;
+
+    @Override
+    public void save(
+            String key,
+            String value,
+            int expireTime
+    ) {
+        ValueOperations<String, String> ops = stringRedisTemplate.opsForValue();
+        ops.set(key, value);
+        stringRedisTemplate.expire(key, expireTime, MINUTES);
+    }
+
+    @Override
+    public String findByKey(
+            String refreshToken
+    ) {
+        ValueOperations<String, String> ops = stringRedisTemplate.opsForValue();
+        return ops.get(refreshToken);
+    }
+
+    @Override
+    public void deleteByKey(
+            String refreshToken
+    ) {
+        stringRedisTemplate.delete(refreshToken);
+    }
+
+    @Override
+    public Boolean saveIfAbsent(
+            String key,
+            String value,
+            long expireTimeInSeconds
+    ) {
+        ValueOperations<String, String> ops = stringRedisTemplate.opsForValue();
+        return ops.setIfAbsent(key, value, expireTimeInSeconds, SECONDS);
+    }
+}

--- a/src/main/java/com/backend/immilog/global/infrastructure/storage/FileStorageHandler.java
+++ b/src/main/java/com/backend/immilog/global/infrastructure/storage/FileStorageHandler.java
@@ -1,0 +1,14 @@
+package com.backend.immilog.global.infrastructure.storage;
+
+import org.springframework.web.multipart.MultipartFile;
+
+public interface FileStorageHandler {
+    String uploadFile(
+            MultipartFile file,
+            String imagePath
+    );
+
+    void deleteFile(
+            String imagePath
+    );
+}

--- a/src/main/java/com/backend/immilog/global/infrastructure/storage/S3FileStorageHandler.java
+++ b/src/main/java/com/backend/immilog/global/infrastructure/storage/S3FileStorageHandler.java
@@ -1,0 +1,80 @@
+package com.backend.immilog.global.infrastructure.storage;
+
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.model.ObjectMetadata;
+import com.backend.immilog.global.exception.CustomException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+import java.util.UUID;
+
+import static com.backend.immilog.global.exception.CommonErrorCode.IMAGE_UPLOAD_FAILED;
+
+@RequiredArgsConstructor
+@Service
+public class S3FileStorageHandler implements FileStorageHandler {
+    private final AmazonS3 amazonS3;
+
+    @Value("${cloud.aws.s3.bucket}")
+    private String bucket;
+
+    @Override
+    public String uploadFile(
+            MultipartFile multipartFile,
+            String imagePath
+    ) {
+        String originalFileName = generateFileName(multipartFile, imagePath);
+        uploadFileToS3(multipartFile, originalFileName);
+        return generateFileUrl(originalFileName);
+    }
+
+    @Override
+    public void deleteFile(String imagePath) {
+        amazonS3.deleteObject(bucket, imagePath);
+    }
+
+    private String generateFileName(
+            MultipartFile multipartFile,
+            String imagePath
+    ) {
+        return imagePath + "/" +
+                UUID.randomUUID()
+                        .toString()
+                        .replace("-", "")
+                        .substring(0, 16)
+                + "." + getFileExtension(multipartFile);
+    }
+
+    private void uploadFileToS3(
+            MultipartFile multipartFile,
+            String originalFileName
+    ) {
+        ObjectMetadata metadata = new ObjectMetadata();
+        metadata.setContentLength(multipartFile.getSize());
+        metadata.setContentType(multipartFile.getContentType());
+
+        try {
+            amazonS3.putObject(bucket, originalFileName, multipartFile.getInputStream(), metadata);
+        } catch (IOException e) {
+            throw new CustomException(IMAGE_UPLOAD_FAILED);
+        }
+    }
+
+    private String generateFileUrl(String originalFileName) {
+        return amazonS3.getUrl(bucket, originalFileName).toString();
+    }
+
+    private String getFileExtension(MultipartFile file) {
+        String originalFilename = file.getOriginalFilename();
+        if (originalFilename != null) {
+            int lastDotIndex = originalFilename.lastIndexOf(".");
+            if (lastDotIndex != -1) {
+                return originalFilename.substring(lastDotIndex + 1);
+            }
+        }
+        return "png";
+    }
+}

--- a/src/main/java/com/backend/immilog/post/application/services/PostUpdateService.java
+++ b/src/main/java/com/backend/immilog/post/application/services/PostUpdateService.java
@@ -1,6 +1,6 @@
 package com.backend.immilog.post.application.services;
 
-import com.backend.immilog.global.application.RedisDistributedLock;
+import com.backend.immilog.global.infrastructure.lock.RedisDistributedLock;
 import com.backend.immilog.post.application.command.PostUpdateCommand;
 import com.backend.immilog.post.exception.PostException;
 import com.backend.immilog.post.model.entities.InteractionUser;

--- a/src/main/java/com/backend/immilog/user/application/services/UserReportService.java
+++ b/src/main/java/com/backend/immilog/user/application/services/UserReportService.java
@@ -1,6 +1,6 @@
 package com.backend.immilog.user.application.services;
 
-import com.backend.immilog.global.application.RedisDistributedLock;
+import com.backend.immilog.global.infrastructure.lock.RedisDistributedLock;
 import com.backend.immilog.user.application.command.UserReportCommand;
 import com.backend.immilog.user.exception.UserException;
 import com.backend.immilog.user.model.entities.Report;

--- a/src/test/java/com/backend/immilog/global/application/RedisDistributedLockTest.java
+++ b/src/test/java/com/backend/immilog/global/application/RedisDistributedLockTest.java
@@ -1,30 +1,28 @@
 package com.backend.immilog.global.application;
-
+import com.backend.immilog.global.infrastructure.lock.RedisDistributedLock;
+import com.backend.immilog.global.infrastructure.repository.DataRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
-import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
 import org.springframework.dao.DataAccessException;
-import org.springframework.data.redis.core.RedisTemplate;
-import org.springframework.data.redis.core.ValueOperations;
-
-import java.util.concurrent.TimeUnit;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.*;
 
+@DisplayName("RedisDistributedLock 테스트")
 class RedisDistributedLockTest {
+
     @Mock
-    private RedisTemplate<String, String> redisTemplate;
+    private DataRepository dataRepository; // DataRepository를 Mock으로 사용
 
     private RedisDistributedLock redisDistributedLock;
 
     @BeforeEach
     void setUp() {
         MockitoAnnotations.openMocks(this);
-        redisDistributedLock = new RedisDistributedLock(redisTemplate);
+        redisDistributedLock = new RedisDistributedLock(dataRepository); // Mock 주입
     }
 
     @Test
@@ -33,26 +31,21 @@ class RedisDistributedLockTest {
         // given
         String lockKey = "lockKey";
         String requestId = "requestId";
-        ValueOperations<String, String> valueOperations = Mockito.mock(ValueOperations.class);
 
-        // 첫 번째와 두 번째 시도는 실패 (false 반환)
-        when(valueOperations.setIfAbsent(
-                lockKey, requestId, 10, TimeUnit.SECONDS
-        ))
+        // 첫 번째와 두 번째 시도는 실패 (false 반환), 세 번째 시도는 성공 (true 반환)
+        when(dataRepository.saveIfAbsent(lockKey, requestId, 10))
                 .thenReturn(false)
                 .thenReturn(false)
                 .thenReturn(true);
-
-        when(redisTemplate.opsForValue()).thenReturn(valueOperations);
 
         // when
         boolean result = redisDistributedLock.tryAcquireLock(lockKey, requestId);
 
         // then
-        assertThat(result).isTrue();
+        assertThat(result).isTrue(); // 락이 성공적으로 획득되었는지 검증
 
-        // 세 번 시도했는지 확인
-        verify(valueOperations, times(3)).setIfAbsent(lockKey, requestId, 10, TimeUnit.SECONDS);
+        // saveIfAbsent가 3번 호출되었는지 확인
+        verify(dataRepository, times(3)).saveIfAbsent(lockKey, requestId, 10);
     }
 
     @Test
@@ -61,16 +54,15 @@ class RedisDistributedLockTest {
         // given
         String lockKey = "lockKey";
         String requestId = "requestId";
-        ValueOperations<String, String> valueOperations = Mockito.mock(ValueOperations.class);
 
-        when(redisTemplate.opsForValue()).thenReturn(valueOperations);
-        when(valueOperations.get(lockKey)).thenReturn(requestId);
+        // dataRepository에서 반환하는 값이 requestId와 일치할 때
+        when(dataRepository.findByKey(lockKey)).thenReturn(requestId);
 
         // when
         redisDistributedLock.releaseLock(lockKey, requestId);
 
         // then
-        verify(redisTemplate, times(1)).delete(lockKey);
+        verify(dataRepository, times(1)).deleteByKey(lockKey); // 삭제되었는지 확인
     }
 
     @Test
@@ -80,16 +72,15 @@ class RedisDistributedLockTest {
         String lockKey = "lockKey";
         String requestId = "requestId";
         String differentRequestId = "differentRequestId";
-        ValueOperations<String, String> valueOperations = Mockito.mock(ValueOperations.class);
 
-        when(redisTemplate.opsForValue()).thenReturn(valueOperations);
-        when(valueOperations.get(lockKey)).thenReturn(differentRequestId);
+        // dataRepository에서 반환하는 값이 requestId와 일치하지 않을 때
+        when(dataRepository.findByKey(lockKey)).thenReturn(differentRequestId);
 
         // when
         redisDistributedLock.releaseLock(lockKey, requestId);
 
         // then
-        verify(redisTemplate, never()).delete(lockKey);
+        verify(dataRepository, never()).deleteByKey(lockKey); // 삭제가 호출되지 않음을 검증
     }
 
     @Test
@@ -98,16 +89,14 @@ class RedisDistributedLockTest {
         // given
         String lockKey = "lockKey";
         String requestId = "requestId";
-        ValueOperations<String, String> valueOperations = Mockito.mock(ValueOperations.class);
 
-        when(redisTemplate.opsForValue()).thenReturn(valueOperations);
-        when(valueOperations.get(lockKey)).thenThrow(new DataAccessException(
-                "Error") {});
+        // 예외가 발생하는 상황을 가정
+        when(dataRepository.findByKey(lockKey)).thenThrow(new DataAccessException("Error") {});
 
         // when
         redisDistributedLock.releaseLock(lockKey, requestId);
 
         // then
-        verify(redisTemplate, never()).delete(lockKey);
+        verify(dataRepository, never()).deleteByKey(lockKey); // 예외가 발생하면 삭제가 호출되지 않음을 검증
     }
 }

--- a/src/test/java/com/backend/immilog/global/application/RedisServiceTest.java
+++ b/src/test/java/com/backend/immilog/global/application/RedisServiceTest.java
@@ -1,12 +1,11 @@
 package com.backend.immilog.global.application;
 
+import com.backend.immilog.global.infrastructure.repository.DataRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
-import org.springframework.data.redis.core.RedisTemplate;
-import org.springframework.data.redis.core.ValueOperations;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.*;
@@ -14,58 +13,58 @@ import static org.mockito.Mockito.*;
 @DisplayName("Redis 키/값 테스트")
 class RedisServiceTest {
     @Mock
-    private RedisTemplate<String, String> stringRedisTemplate;
+    private DataRepository dataRepository;
     private RedisService redisService;
 
     @BeforeEach
     void setUp() {
         MockitoAnnotations.openMocks(this);
-        redisService = new RedisService(stringRedisTemplate);
+        redisService = new RedisService(dataRepository);
     }
 
     @Test
     @DisplayName("키/값 저장")
-    void saveKeyAndValue() {
+    void save() {
         // given
         String key = "key";
         String value = "value";
         int expireTime = 10;
-        ValueOperations<String, String> ops =
-                mock(ValueOperations.class);
-        when(stringRedisTemplate.opsForValue())
-                .thenReturn(ops);
+
         // when
         redisService.saveKeyAndValue(key, value, expireTime);
+
         // then
-        verify(ops).set(key, value);
+        verify(dataRepository, times(1)).save(key, value, expireTime);
     }
 
     @Test
     @DisplayName("키로 값 가져오기")
-    void getValueByKey() {
+    void findByKey() {
         // given
         String key = "key";
-        String value = "value";
-        ValueOperations<String, String> ops =
-                mock(ValueOperations.class);
-        when(stringRedisTemplate.opsForValue())
-                .thenReturn(ops);
-        when(ops.get(key))
-                .thenReturn(value);
+        String expectedValue = "value";
+
+        when(dataRepository.findByKey(key)).thenReturn(expectedValue);
+
         // when
         String result = redisService.getValueByKey(key);
+
         // then
-        assertThat(result).isEqualTo(value);
+        assertThat(result).isEqualTo(expectedValue);
+        verify(dataRepository, times(1)).findByKey(key);
     }
 
     @Test
     @DisplayName("키로 값 삭제")
-    void deleteValueByKey() {
+    void deleteByKey() {
         // given
         String key = "key";
+
         // when
         redisService.deleteValueByKey(key);
+
         // then
-        verify(stringRedisTemplate).delete(key);
+        verify(dataRepository, times(1)).deleteByKey(key);
     }
 }
+

--- a/src/test/java/com/backend/immilog/global/configuration/AsyncConfigTest.java
+++ b/src/test/java/com/backend/immilog/global/configuration/AsyncConfigTest.java
@@ -10,10 +10,10 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.core.task.AsyncTaskExecutor;
 import org.springframework.scheduling.annotation.AsyncConfigurer;
 import org.springframework.scheduling.annotation.EnableAsync;
-import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
 
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Executor;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -25,22 +25,17 @@ class AsyncConfigTest {
     @Autowired
     private AsyncConfigurer asyncConfigurer;
 
-    private AsyncTaskExecutor executor;
+    private Executor executor;
 
     @BeforeEach
     void setUp() {
-        executor = (AsyncTaskExecutor) asyncConfigurer.getAsyncExecutor();
+        executor = asyncConfigurer.getAsyncExecutor();
     }
 
     @Test
     @DisplayName("AsyncExecutor 설정")
     void asyncExecutorIsConfiguredCorrectly() {
-        assertThat(executor).isInstanceOf(ThreadPoolTaskExecutor.class);
-
-        ThreadPoolTaskExecutor threadPoolExecutor = (ThreadPoolTaskExecutor) executor;
-        assertThat(threadPoolExecutor.getCorePoolSize()).isEqualTo(2);
-        assertThat(threadPoolExecutor.getMaxPoolSize()).isEqualTo(10);
-        assertThat(threadPoolExecutor.getThreadNamePrefix()).isEqualTo("async-");
+        assertThat(executor).isNotNull();
     }
 
     @Test

--- a/src/test/java/com/backend/immilog/post/application/PostUpdateServiceTest.java
+++ b/src/test/java/com/backend/immilog/post/application/PostUpdateServiceTest.java
@@ -1,6 +1,6 @@
 package com.backend.immilog.post.application;
 
-import com.backend.immilog.global.application.RedisDistributedLock;
+import com.backend.immilog.global.infrastructure.lock.RedisDistributedLock;
 import com.backend.immilog.post.application.services.PostUpdateService;
 import com.backend.immilog.post.exception.PostException;
 import com.backend.immilog.post.model.embeddables.PostMetaData;

--- a/src/test/java/com/backend/immilog/user/application/UserReportServiceTest.java
+++ b/src/test/java/com/backend/immilog/user/application/UserReportServiceTest.java
@@ -1,6 +1,6 @@
 package com.backend.immilog.user.application;
 
-import com.backend.immilog.global.application.RedisDistributedLock;
+import com.backend.immilog.global.infrastructure.lock.RedisDistributedLock;
 import com.backend.immilog.user.application.services.UserReportService;
 import com.backend.immilog.user.enums.ReportReason;
 import com.backend.immilog.user.exception.UserException;


### PR DESCRIPTION
* chore (build) : 프로젝트 java version 17 -> 21 업그레이드

* chore (build) : 가상 스레드 기반 비동기 처리로 변경

- ThreadPoolTaskExecutor 대신 가상 스레드를 사용하도록 AsyncConfig 수정
- Executors.newVirtualThreadPerTaskExecutor() 사용해 대규모 동시 작업 처리 지원
- 더 가벼운 스레드 관리로 성능 향상 기대

* test (build) : 가상 스레드 기반 비동기 처리 테스트 코드 수정

* feat (global) : ImageService S3 bucket 인터페이스 추상화

- 추상화 / 의존성 주입을 통한 의존성 낮춤
- 코드가 특정 클라우드 서비스에 종속되지 않고, 확장성과 테스트 가능성 증대

* test (global) : ImageService S3 bucket 인터페이스 추상화로 인한 테스트 코드 수정

* feat (global) : RedisTemplate 의존성 DataRepository 인터페이스로 추상화

- RedisTemplate 의존성을 DataRepository 인터페이스로 추상화
- RedisDistributedLock에서 DataRepository를 사용하도록 수정
- 관련 테스트 코드 수정 및 리팩토링

* test (global) : DataRepository 추상화 관련 테스트 코드 수정