### PR TITLE
feat (post) : 계층 간 DTO 분리로 레이어 간 의존성 최소화

### DIFF
--- a/src/main/java/com/backend/immilog/post/application/result/PostResult.java
+++ b/src/main/java/com/backend/immilog/post/application/result/PostResult.java
@@ -1,111 +1,59 @@
 package com.backend.immilog.post.application.result;
 
-import com.backend.immilog.post.domain.vo.PostMetaData;
-import com.backend.immilog.post.domain.vo.PostUserData;
-import com.backend.immilog.post.domain.model.InteractionUser;
-import com.backend.immilog.post.domain.model.Post;
-import com.backend.immilog.post.domain.model.PostResource;
 import com.backend.immilog.post.domain.enums.Categories;
-import com.backend.immilog.post.domain.enums.InteractionType;
 import com.backend.immilog.post.domain.enums.PostStatus;
-import com.backend.immilog.post.domain.enums.ResourceType;
-import lombok.Getter;
-import lombok.Setter;
-import lombok.ToString;
+import lombok.Builder;
 
-import java.util.ArrayList;
 import java.util.List;
-import java.util.Objects;
 
-import static com.backend.immilog.post.domain.enums.InteractionType.BOOKMARK;
-import static com.backend.immilog.post.domain.enums.InteractionType.LIKE;
-import static com.backend.immilog.post.domain.enums.ResourceType.ATTACHMENT;
-import static com.backend.immilog.post.domain.enums.ResourceType.TAG;
-
-@Getter
-@Setter
-@ToString
-public class PostResult {
-    private Long seq;
-    private String title;
-    private String content;
-    private Long userSeq;
-    private String userProfileUrl;
-    private String userNickName;
-    private List<CommentResult> comments;
-    private Long commentCount;
-    private Long viewCount;
-    private Long likeCount;
-    private List<String> tags;
-    private List<String> attachments;
-    private List<Long> likeUsers;
-    private List<Long> bookmarkUsers;
-    private String isPublic;
-    private String country;
-    private String region;
-    private Categories category;
-    private PostStatus status;
-    private String createdAt;
-
-    public PostResult(
-            Post post,
-            List<InteractionUser> interactionUsers,
-            List<PostResource> postResources
+@Builder
+public record PostResult(
+        Long seq,
+        String title,
+        String content,
+        Long userSeq,
+        String userProfileUrl,
+        String userNickName,
+        List<CommentResult> comments,
+        Long commentCount,
+        Long viewCount,
+        Long likeCount,
+        List<String> tags,
+        List<String> attachments,
+        List<Long> likeUsers,
+        List<Long> bookmarkUsers,
+        String isPublic,
+        String country,
+        String region,
+        Categories category,
+        PostStatus status,
+        String createdAt
+) {
+    public PostResult copyWithNewComments(
+            List<CommentResult> comments
     ) {
-        interactionUsers = interactionUsers != null ? interactionUsers : List.of();
-        postResources = postResources != null ? postResources : List.of();
-        PostMetaData postMetaData = post.postMetaData();
-        PostUserData postUserData = post.postUserData();
+        return PostResult.builder()
+                .seq(this.seq())
+                .title(this.title())
+                .content(this.content())
+                .userSeq(this.userSeq())
+                .userProfileUrl(this.userProfileUrl())
+                .userNickName(this.userNickName())
+                .comments(comments)
+                .commentCount(this.commentCount())
+                .viewCount(this.viewCount())
+                .likeCount(this.likeCount())
+                .tags(this.tags())
+                .attachments(this.attachments())
+                .likeUsers(this.likeUsers())
+                .bookmarkUsers(this.bookmarkUsers())
+                .isPublic(this.isPublic())
+                .country(this.country())
+                .region(this.region())
+                .category(this.category())
+                .status(this.status())
+                .createdAt(this.createdAt())
+                .build();
 
-        List<Long> likeUsers = getLongs(interactionUsers, post, LIKE);
-        List<Long> bookmarkUsers = getLongs(interactionUsers, post, BOOKMARK);
-        List<String> tags = getStrings(postResources, post, TAG);
-        List<String> attachments = getStrings(postResources, post, ATTACHMENT);
-
-        this.seq = post.seq();
-        this.title = postMetaData.getTitle();
-        this.content = postMetaData.getContent();
-        this.userSeq = postUserData.getUserSeq();
-        this.userProfileUrl = postUserData.getProfileImage();
-        this.userNickName = postUserData.getNickname();
-        this.country = postMetaData.getCountry().getCountryName();
-        this.region = postMetaData.getRegion();
-        this.viewCount = postMetaData.getViewCount();
-        this.likeCount = postMetaData.getLikeCount();
-        this.commentCount = post.commentCount();
-        this.comments = new ArrayList<>();
-        this.likeUsers = likeUsers;
-        this.bookmarkUsers = bookmarkUsers;
-        this.tags = tags;
-        this.attachments = attachments;
-        this.isPublic = post.isPublic();
-        this.status = postMetaData.getStatus();
-        this.category = post.category();
-        this.createdAt = post.createdAt().toString();
     }
-
-    private static List<String> getStrings(
-            List<PostResource> postResources,
-            Post post,
-            ResourceType type
-    ) {
-        return postResources.stream()
-                .filter(Objects::nonNull)
-                .filter(c -> c.resourceType().equals(type))
-                .map(PostResource::content)
-                .toList();
-    }
-
-    private static List<Long> getLongs(
-            List<InteractionUser> interactionUsers,
-            Post post,
-            InteractionType type
-    ) {
-        return interactionUsers.stream()
-                .filter(Objects::nonNull)
-                .filter(c -> c.interactionType().equals(type))
-                .map(InteractionUser::userSeq)
-                .toList();
-    }
-
 }

--- a/src/main/java/com/backend/immilog/post/application/services/PostInquiryService.java
+++ b/src/main/java/com/backend/immilog/post/application/services/PostInquiryService.java
@@ -52,7 +52,7 @@ public class PostInquiryService {
     ) {
         PostResult postResult = getPostDTO(postSeq);
         List<CommentResult> comments = commentRepository.getComments(postSeq);
-        postResult.setComments(comments);
+        postResult = postResult.copyWithNewComments(comments);
         return postResult;
     }
 

--- a/src/main/java/com/backend/immilog/post/infrastructure/repositories/CommentRepositoryImpl.java
+++ b/src/main/java/com/backend/immilog/post/infrastructure/repositories/CommentRepositoryImpl.java
@@ -6,6 +6,7 @@ import com.backend.immilog.post.domain.repositories.CommentRepository;
 import com.backend.immilog.post.infrastructure.jpa.entities.CommentEntity;
 import com.backend.immilog.post.infrastructure.jpa.entities.QCommentEntity;
 import com.backend.immilog.post.infrastructure.jpa.repository.CommentJpaRepository;
+import com.backend.immilog.post.infrastructure.result.CommentEntityResult;
 import com.backend.immilog.user.infrastructure.jpa.entity.QUserEntity;
 import com.querydsl.core.types.Projections;
 import com.querydsl.jpa.impl.JPAQueryFactory;
@@ -52,14 +53,17 @@ public class CommentRepositoryImpl implements CommentRepository {
                 .transform(
                         groupBy(comment.postSeq).list(
                                 Projections.constructor(
-                                        CommentResult.class,
+                                        CommentEntityResult.class,
                                         comment,
                                         user,
                                         Projections.list(childComment),
                                         Projections.list(childCommentUser)
                                 )
                         )
-                );
+                )
+                .stream()
+                .map(CommentEntityResult::toCommentResult)
+                .toList();
     }
 
     @Override

--- a/src/main/java/com/backend/immilog/post/infrastructure/repositories/PostRepositoryImpl.java
+++ b/src/main/java/com/backend/immilog/post/infrastructure/repositories/PostRepositoryImpl.java
@@ -11,6 +11,7 @@ import com.backend.immilog.post.infrastructure.jpa.entities.QInteractionUserEnti
 import com.backend.immilog.post.infrastructure.jpa.entities.QPostEntity;
 import com.backend.immilog.post.infrastructure.jpa.entities.QPostResourceEntity;
 import com.backend.immilog.post.infrastructure.jpa.repository.PostJpaRepository;
+import com.backend.immilog.post.infrastructure.result.PostEntityResult;
 import com.querydsl.core.BooleanBuilder;
 import com.querydsl.core.types.OrderSpecifier;
 import com.querydsl.core.types.Predicate;
@@ -66,13 +67,15 @@ public class PostRepositoryImpl implements PostRepository {
                 .transform(
                         groupBy(post.seq).list(
                                 Projections.constructor(
-                                        PostResult.class,
+                                        PostEntityResult.class,
                                         post,
                                         list(interUser),
                                         list(resource)
                                 )
                         )
-                );
+                ).stream()
+                .map(PostEntityResult::toPostResult)
+                .toList();
 
         long total = getSize(post, predicate);
         return new PageImpl<>(postResults, pageable, total);
@@ -99,7 +102,7 @@ public class PostRepositoryImpl implements PostRepository {
                         groupBy(post.seq)
                                 .list(
                                         Projections.constructor(
-                                                PostResult.class,
+                                                PostEntityResult.class,
                                                 post,
                                                 list(interUser),
                                                 list(resource)
@@ -107,6 +110,7 @@ public class PostRepositoryImpl implements PostRepository {
                                 )
                 )
                 .stream()
+                .map(PostEntityResult::toPostResult)
                 .findFirst();
     }
 
@@ -132,13 +136,17 @@ public class PostRepositoryImpl implements PostRepository {
                         groupBy(post.seq)
                                 .list(
                                         Projections.constructor(
-                                                PostResult.class,
+                                                PostEntityResult.class,
                                                 post,
                                                 list(interUser),
                                                 list(resource)
                                         )
                                 )
-                );
+                )
+                .stream()
+                .map(PostEntityResult::toPostResult)
+                .toList();
+
         long total = getSize(post, resource, interUser, predicate);
         return new PageImpl<>(postResults, pageable, total);
     }
@@ -165,13 +173,16 @@ public class PostRepositoryImpl implements PostRepository {
                         groupBy(post.seq)
                                 .list(
                                         Projections.constructor(
-                                                PostResult.class,
+                                                PostEntityResult.class,
                                                 post,
                                                 list(interUser),
                                                 list(resource)
                                         )
                                 )
-                );
+                )
+                .stream()
+                .map(PostEntityResult::toPostResult)
+                .toList();
         long total = getSize(post, resource, interUser, predicate);
         return new PageImpl<>(postResults, pageable, total);
     }

--- a/src/main/java/com/backend/immilog/post/infrastructure/result/CommentEntityResult.java
+++ b/src/main/java/com/backend/immilog/post/infrastructure/result/CommentEntityResult.java
@@ -1,0 +1,105 @@
+package com.backend.immilog.post.infrastructure.result;
+
+import com.backend.immilog.post.application.result.CommentResult;
+import com.backend.immilog.post.domain.enums.PostStatus;
+import com.backend.immilog.post.domain.model.Comment;
+import com.backend.immilog.user.application.result.UserInfoResult;
+import com.backend.immilog.user.domain.model.User;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class CommentEntityResult {
+    private Long seq;
+    private UserInfoResult user;
+    private String content;
+    private List<CommentEntityResult> replies;
+    private int upVotes;
+    private int downVotes;
+    private int replyCount;
+    private List<Long> likeUsers;
+    private PostStatus status;
+    private LocalDateTime createdAt;
+
+    public CommentEntityResult(
+            Comment comment,
+            User user,
+            List<Comment> replies,
+            List<User> replyUsers
+    ) {
+        List<CommentEntityResult> replyList = combineReplies(replies, replyUsers);
+
+        this.seq = comment.seq();
+        this.user = UserInfoResult.from(user);
+        this.content = comment.content();
+        this.replies = replyList;
+        this.upVotes = comment.likeCount();
+        this.replyCount = comment.replyCount();
+        this.likeUsers = comment.likeUsers();
+        this.status = comment.status();
+        this.createdAt = comment.createdAt();
+    }
+
+    public static CommentEntityResult of(
+            Comment comment,
+            User user
+    ) {
+        return CommentEntityResult.builder()
+                .seq(comment.seq())
+                .user(UserInfoResult.from(user))
+                .content(comment.content())
+                .replies(new ArrayList<>())
+                .upVotes(comment.likeCount())
+                .replyCount(comment.replyCount())
+                .likeUsers(comment.likeUsers())
+                .status(comment.status())
+                .createdAt(comment.createdAt())
+                .build();
+    }
+
+    private List<CommentEntityResult> combineReplies(
+            List<Comment> replies,
+            List<User> replyUsers
+    ) {
+        if (replies.isEmpty() || replyUsers.isEmpty()) {
+            return List.of();
+        }
+        return replies
+                .stream()
+                .map(reply -> {
+                    return replyUsers.stream()
+                            .filter(Objects::nonNull)
+                            .filter(u -> u.seq().equals(reply.userSeq()))
+                            .findFirst()
+                            .map(replyUser -> CommentEntityResult.of(reply, replyUser))
+                            .orElse(null);
+                })
+                .filter(Objects::nonNull)
+                .toList();
+    }
+
+    public CommentResult toCommentResult() {
+        return CommentResult.builder()
+                .seq(seq)
+                .user(user)
+                .content(content)
+                .replies(replies.stream().map(CommentEntityResult::toCommentResult).toList())
+                .upVotes(upVotes)
+                .downVotes(downVotes)
+                .replyCount(replyCount)
+                .likeUsers(likeUsers)
+                .status(status)
+                .createdAt(createdAt)
+                .build();
+    }
+}

--- a/src/main/java/com/backend/immilog/post/infrastructure/result/PostEntityResult.java
+++ b/src/main/java/com/backend/immilog/post/infrastructure/result/PostEntityResult.java
@@ -1,0 +1,135 @@
+package com.backend.immilog.post.infrastructure.result;
+
+import com.backend.immilog.post.application.result.PostResult;
+import com.backend.immilog.post.domain.enums.Categories;
+import com.backend.immilog.post.domain.enums.InteractionType;
+import com.backend.immilog.post.domain.enums.PostStatus;
+import com.backend.immilog.post.domain.enums.ResourceType;
+import com.backend.immilog.post.domain.vo.PostMetaData;
+import com.backend.immilog.post.domain.vo.PostUserData;
+import com.backend.immilog.post.infrastructure.jpa.entities.InteractionUserEntity;
+import com.backend.immilog.post.infrastructure.jpa.entities.PostEntity;
+import com.backend.immilog.post.infrastructure.jpa.entities.PostResourceEntity;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+import static com.backend.immilog.post.domain.enums.InteractionType.BOOKMARK;
+import static com.backend.immilog.post.domain.enums.InteractionType.LIKE;
+import static com.backend.immilog.post.domain.enums.ResourceType.ATTACHMENT;
+import static com.backend.immilog.post.domain.enums.ResourceType.TAG;
+
+@Getter
+@Setter
+@ToString
+public class PostEntityResult {
+    private Long seq;
+    private String title;
+    private String content;
+    private Long userSeq;
+    private String userProfileUrl;
+    private String userNickName;
+    private List<CommentEntityResult> comments;
+    private Long commentCount;
+    private Long viewCount;
+    private Long likeCount;
+    private List<String> tags;
+    private List<String> attachments;
+    private List<Long> likeUsers;
+    private List<Long> bookmarkUsers;
+    private String isPublic;
+    private String country;
+    private String region;
+    private Categories category;
+    private PostStatus status;
+    private String createdAt;
+
+    public PostEntityResult(
+            PostEntity post,
+            List<InteractionUserEntity> interactionUsers,
+            List<PostResourceEntity> postResources
+    ) {
+        interactionUsers = interactionUsers != null ? interactionUsers : List.of();
+        postResources = postResources != null ? postResources : List.of();
+        PostMetaData postMetaData = post.getPostMetaData();
+        PostUserData postUserData = post.getPostUserData();
+
+        List<Long> likeUsers = getLongs(interactionUsers, LIKE);
+        List<Long> bookmarkUsers = getLongs(interactionUsers, BOOKMARK);
+        List<String> tags = getStrings(postResources, TAG);
+        List<String> attachments = getStrings(postResources, ATTACHMENT);
+
+        this.seq = post.getSeq();
+        this.title = postMetaData.getTitle();
+        this.content = postMetaData.getContent();
+        this.userSeq = postUserData.getUserSeq();
+        this.userProfileUrl = postUserData.getProfileImage();
+        this.userNickName = postUserData.getNickname();
+        this.country = postMetaData.getCountry().getCountryName();
+        this.region = postMetaData.getRegion();
+        this.viewCount = postMetaData.getViewCount();
+        this.likeCount = postMetaData.getLikeCount();
+        this.commentCount = post.getCommentCount();
+        this.comments = new ArrayList<>();
+        this.likeUsers = likeUsers;
+        this.bookmarkUsers = bookmarkUsers;
+        this.tags = tags;
+        this.attachments = attachments;
+        this.isPublic = post.getIsPublic();
+        this.status = postMetaData.getStatus();
+        this.category = post.getCategory();
+        this.createdAt = post.getCreatedAt().toString();
+    }
+
+    private static List<String> getStrings(
+            List<PostResourceEntity> postResources,
+            ResourceType type
+    ) {
+        return postResources.stream()
+                .filter(Objects::nonNull)
+                .filter(c -> c.getResourceType().equals(type))
+                .map(PostResourceEntity::getContent)
+                .toList();
+    }
+
+    private static List<Long> getLongs(
+            List<InteractionUserEntity> interactionUsers,
+            InteractionType type
+    ) {
+        return interactionUsers.stream()
+                .filter(Objects::nonNull)
+                .filter(c -> c.getInteractionType().equals(type))
+                .map(InteractionUserEntity::getUserSeq)
+                .toList();
+    }
+
+    public PostResult toPostResult() {
+        return PostResult.builder()
+                .seq(seq)
+                .title(title)
+                .content(content)
+                .userSeq(userSeq)
+                .userProfileUrl(userProfileUrl)
+                .userNickName(userNickName)
+                .country(country)
+                .region(region)
+                .viewCount(viewCount)
+                .likeCount(likeCount)
+                .commentCount(commentCount)
+                .comments(new ArrayList<>())
+                .likeUsers(likeUsers)
+                .bookmarkUsers(bookmarkUsers)
+                .tags(tags)
+                .attachments(attachments)
+                .isPublic(isPublic)
+                .status(status)
+                .category(category)
+                .createdAt(createdAt)
+                .build();
+    }
+
+}

--- a/src/test/java/com/backend/immilog/post/presentation/controller/PostControllerTest.java
+++ b/src/test/java/com/backend/immilog/post/presentation/controller/PostControllerTest.java
@@ -207,7 +207,7 @@ class PostControllerTest {
         Long postSeq = 1L;
         PostResult postResult = mock(PostResult.class);
         when(postInquiryService.getPost(postSeq)).thenReturn(postResult);
-        when(postResult.getSeq()).thenReturn(postSeq);
+        when(postResult.seq()).thenReturn(postSeq);
 
         // when
         ResponseEntity<PostApiResponse> response = postController.getPost(postSeq);
@@ -215,7 +215,7 @@ class PostControllerTest {
         // then
         assertThat(response.getStatusCode()).isEqualTo(OK);
         assertThat(Objects.requireNonNull(response.getBody()).data()).isEqualTo(postResult);
-        assertThat(((PostResult) (response.getBody()).data()).getSeq()).isEqualTo(postSeq);
+        assertThat(((PostResult) (response.getBody()).data()).seq()).isEqualTo(postSeq);
     }
 
     @Test


### PR DESCRIPTION
### 작업 내용
- QueryDsl로 반환하던 application 레이어의 DTO대신 infrastructure 계층의
   DTO를 새로 만들어주고 반환/변환 함으로써 계층간 의존성을 낮춤과 동시에 
   QueryDSL을 사용하며 발생하는 DTO 생성자 이슈(Projection Constructor 인자 문제) 해결

### 특이 사항
- 없음
